### PR TITLE
feat(api): set up API routes for content CRUD operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,21 @@
 # =============================================================================
 # Get your connection string from https://neon.tech → Project → Connection Details
 DATABASE_URL="postgresql://user:password@ep-xxx.region.aws.neon.tech/neondb?sslmode=require"
+
+# =============================================================================
+# Authentication (NextAuth)
+# =============================================================================
+# Generate a secret: openssl rand -base64 32
+NEXTAUTH_SECRET="your-secret-here"
+NEXTAUTH_URL="http://localhost:3000"
+
+# =============================================================================
+# OAuth Providers (optional — leave blank to disable)
+# =============================================================================
+# Google: https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=""
+GOOGLE_CLIENT_SECRET=""
+
+# GitHub: https://github.com/settings/developers
+GITHUB_CLIENT_ID=""
+GITHUB_CLIENT_SECRET=""

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,22 +8,29 @@
    "name": "atlas",
    "version": "0.1.0",
    "dependencies": {
+    "@auth/prisma-adapter": "^2.11.1",
     "@base-ui/react": "^1.3.0",
+    "@neondatabase/serverless": "^1.0.2",
+    "@prisma/adapter-neon": "^7.5.0",
     "@prisma/client": "^7.5.0",
+    "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
     "next": "16.2.0",
+    "next-auth": "^4.24.13",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
    },
    "devDependencies": {
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@tailwindcss/postcss": "^4",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -49,6 +56,146 @@
    },
    "funding": {
     "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/@auth/core": {
+   "version": "0.34.3",
+   "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.3.tgz",
+   "integrity": "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==",
+   "license": "ISC",
+   "optional": true,
+   "peer": true,
+   "dependencies": {
+    "@panva/hkdf": "^1.1.1",
+    "@types/cookie": "0.6.0",
+    "cookie": "0.6.0",
+    "jose": "^5.1.3",
+    "oauth4webapi": "^2.10.4",
+    "preact": "10.11.3",
+    "preact-render-to-string": "5.2.3"
+   },
+   "peerDependencies": {
+    "@simplewebauthn/browser": "^9.0.1",
+    "@simplewebauthn/server": "^9.0.2",
+    "nodemailer": "^7"
+   },
+   "peerDependenciesMeta": {
+    "@simplewebauthn/browser": {
+     "optional": true
+    },
+    "@simplewebauthn/server": {
+     "optional": true
+    },
+    "nodemailer": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@auth/core/node_modules/cookie": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+   "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true,
+   "engines": {
+    "node": ">= 0.6"
+   }
+  },
+  "node_modules/@auth/core/node_modules/jose": {
+   "version": "5.10.0",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+   "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true,
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/@auth/core/node_modules/preact": {
+   "version": "10.11.3",
+   "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+   "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true,
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/@auth/core/node_modules/preact-render-to-string": {
+   "version": "5.2.3",
+   "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+   "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true,
+   "dependencies": {
+    "pretty-format": "^3.8.0"
+   },
+   "peerDependencies": {
+    "preact": ">=10"
+   }
+  },
+  "node_modules/@auth/prisma-adapter": {
+   "version": "2.11.1",
+   "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
+   "integrity": "sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==",
+   "license": "ISC",
+   "dependencies": {
+    "@auth/core": "0.41.1"
+   },
+   "peerDependencies": {
+    "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
+   }
+  },
+  "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
+   "version": "0.41.1",
+   "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
+   "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
+   "license": "ISC",
+   "dependencies": {
+    "@panva/hkdf": "^1.2.1",
+    "jose": "^6.0.6",
+    "oauth4webapi": "^3.3.0",
+    "preact": "10.24.3",
+    "preact-render-to-string": "6.5.11"
+   },
+   "peerDependencies": {
+    "@simplewebauthn/browser": "^9.0.1",
+    "@simplewebauthn/server": "^9.0.2",
+    "nodemailer": "^7.0.7"
+   },
+   "peerDependenciesMeta": {
+    "@simplewebauthn/browser": {
+     "optional": true
+    },
+    "@simplewebauthn/server": {
+     "optional": true
+    },
+    "nodemailer": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@auth/prisma-adapter/node_modules/oauth4webapi": {
+   "version": "3.8.5",
+   "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+   "integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/@auth/prisma-adapter/node_modules/preact-render-to-string": {
+   "version": "6.5.11",
+   "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+   "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "preact": ">=10"
    }
   },
   "node_modules/@babel/code-frame": {
@@ -1973,6 +2120,28 @@
     "@tybys/wasm-util": "^0.10.0"
    }
   },
+  "node_modules/@neondatabase/serverless": {
+   "version": "1.0.2",
+   "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.0.2.tgz",
+   "integrity": "sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/node": "^22.15.30",
+    "@types/pg": "^8.8.0"
+   },
+   "engines": {
+    "node": ">=19.0.0"
+   }
+  },
+  "node_modules/@neondatabase/serverless/node_modules/@types/node": {
+   "version": "22.19.15",
+   "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+   "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+   "license": "MIT",
+   "dependencies": {
+    "undici-types": "~6.21.0"
+   }
+  },
   "node_modules/@next/env": {
    "version": "16.2.0",
    "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.0.tgz",
@@ -2203,6 +2372,26 @@
    "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
    "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="
   },
+  "node_modules/@panva/hkdf": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+   "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/@prisma/adapter-neon": {
+   "version": "7.5.0",
+   "resolved": "https://registry.npmjs.org/@prisma/adapter-neon/-/adapter-neon-7.5.0.tgz",
+   "integrity": "sha512-bkblYV6UG2PoQNAbMANR11rmsLFeXJ1u7klN3wIVmo/4v0KXFORZFfjnP1r5UQzM4CN/SSuqDThHKgi1d97tjQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@neondatabase/serverless": ">0.6.0 <2",
+    "@prisma/driver-adapter-utils": "7.5.0",
+    "postgres-array": "3.0.4"
+   }
+  },
   "node_modules/@prisma/client": {
    "version": "7.5.0",
    "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.5.0.tgz",
@@ -2250,7 +2439,6 @@
    "version": "7.5.0",
    "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.5.0.tgz",
    "integrity": "sha512-163+nffny0JoPEkDhfNco0vcuT3ymIJc9+WX7MHSQhfkeKUmKe9/wqvGk5SjppT93DtBjVwr5HPJYlXbzm6qtg==",
-   "devOptional": true,
    "license": "Apache-2.0"
   },
   "node_modules/@prisma/dev": {
@@ -2300,6 +2488,15 @@
    "license": "MIT",
    "engines": {
     "node": ">=16.9.0"
+   }
+  },
+  "node_modules/@prisma/driver-adapter-utils": {
+   "version": "7.5.0",
+   "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.5.0.tgz",
+   "integrity": "sha512-B79N/amgV677mFesFDBAdrW0OIaqawap9E0sjgLBtzIz2R3hIMS1QB8mLZuUEiS4q5Y8Oh3I25Kw4SLxMypk9Q==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@prisma/debug": "7.5.0"
    }
   },
   "node_modules/@prisma/engines": {
@@ -2794,6 +2991,21 @@
     "tslib": "^2.4.0"
    }
   },
+  "node_modules/@types/bcryptjs": {
+   "version": "2.4.6",
+   "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+   "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+   "dev": true,
+   "license": "MIT"
+  },
+  "node_modules/@types/cookie": {
+   "version": "0.6.0",
+   "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+   "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true
+  },
   "node_modules/@types/estree": {
    "version": "1.0.8",
    "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2816,9 +3028,19 @@
    "version": "20.19.37",
    "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
    "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-   "devOptional": true,
    "dependencies": {
     "undici-types": "~6.21.0"
+   }
+  },
+  "node_modules/@types/pg": {
+   "version": "8.20.0",
+   "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+   "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+   "license": "MIT",
+   "dependencies": {
+    "@types/node": "*",
+    "pg-protocol": "*",
+    "pg-types": "^2.2.0"
    }
   },
   "node_modules/@types/react": {
@@ -3767,6 +3989,15 @@
    },
    "engines": {
     "node": ">=6.0.0"
+   }
+  },
+  "node_modules/bcryptjs": {
+   "version": "3.0.3",
+   "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+   "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+   "license": "BSD-3-Clause",
+   "bin": {
+    "bcrypt": "bin/bcrypt"
    }
   },
   "node_modules/body-parser": {
@@ -8077,6 +8308,47 @@
     }
    }
   },
+  "node_modules/next-auth": {
+   "version": "4.24.13",
+   "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.13.tgz",
+   "integrity": "sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==",
+   "license": "ISC",
+   "dependencies": {
+    "@babel/runtime": "^7.20.13",
+    "@panva/hkdf": "^1.0.2",
+    "cookie": "^0.7.0",
+    "jose": "^4.15.5",
+    "oauth": "^0.9.15",
+    "openid-client": "^5.4.0",
+    "preact": "^10.6.3",
+    "preact-render-to-string": "^5.1.19",
+    "uuid": "^8.3.2"
+   },
+   "peerDependencies": {
+    "@auth/core": "0.34.3",
+    "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
+    "nodemailer": "^7.0.7",
+    "react": "^17.0.2 || ^18 || ^19",
+    "react-dom": "^17.0.2 || ^18 || ^19"
+   },
+   "peerDependenciesMeta": {
+    "@auth/core": {
+     "optional": true
+    },
+    "nodemailer": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/next-auth/node_modules/jose": {
+   "version": "4.15.9",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+   "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
   "node_modules/next/node_modules/postcss": {
    "version": "8.4.31",
    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8221,12 +8493,38 @@
    "devOptional": true,
    "license": "MIT"
   },
+  "node_modules/oauth": {
+   "version": "0.9.15",
+   "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+   "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+   "license": "MIT"
+  },
+  "node_modules/oauth4webapi": {
+   "version": "2.17.0",
+   "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+   "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+   "license": "MIT",
+   "optional": true,
+   "peer": true,
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
   "node_modules/object-assign": {
    "version": "4.1.1",
    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
    "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
    "engines": {
     "node": ">=0.10.0"
+   }
+  },
+  "node_modules/object-hash": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+   "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+   "license": "MIT",
+   "engines": {
+    "node": ">= 6"
    }
   },
   "node_modules/object-inspect": {
@@ -8349,6 +8647,15 @@
    "devOptional": true,
    "license": "MIT"
   },
+  "node_modules/oidc-token-hash": {
+   "version": "5.2.0",
+   "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+   "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+   "license": "MIT",
+   "engines": {
+    "node": "^10.13.0 || >=12.0.0"
+   }
+  },
   "node_modules/on-finished": {
    "version": "2.4.1",
    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -8400,6 +8707,48 @@
    "funding": {
     "url": "https://github.com/sponsors/sindresorhus"
    }
+  },
+  "node_modules/openid-client": {
+   "version": "5.7.1",
+   "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+   "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+   "license": "MIT",
+   "dependencies": {
+    "jose": "^4.15.9",
+    "lru-cache": "^6.0.0",
+    "object-hash": "^2.2.0",
+    "oidc-token-hash": "^5.0.3"
+   },
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/openid-client/node_modules/jose": {
+   "version": "4.15.9",
+   "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+   "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+   "license": "MIT",
+   "funding": {
+    "url": "https://github.com/sponsors/panva"
+   }
+  },
+  "node_modules/openid-client/node_modules/lru-cache": {
+   "version": "6.0.0",
+   "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+   "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+   "license": "ISC",
+   "dependencies": {
+    "yallist": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
+  },
+  "node_modules/openid-client/node_modules/yallist": {
+   "version": "4.0.0",
+   "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+   "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+   "license": "ISC"
   },
   "node_modules/optionator": {
    "version": "0.9.4",
@@ -8597,6 +8946,46 @@
    "devOptional": true,
    "license": "MIT"
   },
+  "node_modules/pg-int8": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+   "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+   "license": "ISC",
+   "engines": {
+    "node": ">=4.0.0"
+   }
+  },
+  "node_modules/pg-protocol": {
+   "version": "1.13.0",
+   "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+   "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+   "license": "MIT"
+  },
+  "node_modules/pg-types": {
+   "version": "2.2.0",
+   "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+   "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+   "license": "MIT",
+   "dependencies": {
+    "pg-int8": "1.0.1",
+    "postgres-array": "~2.0.0",
+    "postgres-bytea": "~1.0.0",
+    "postgres-date": "~1.0.4",
+    "postgres-interval": "^1.1.0"
+   },
+   "engines": {
+    "node": ">=4"
+   }
+  },
+  "node_modules/pg-types/node_modules/postgres-array": {
+   "version": "2.0.0",
+   "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+   "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=4"
+   }
+  },
   "node_modules/picocolors": {
    "version": "1.1.1",
    "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8695,6 +9084,45 @@
     "url": "https://github.com/sponsors/porsager"
    }
   },
+  "node_modules/postgres-array": {
+   "version": "3.0.4",
+   "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+   "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=12"
+   }
+  },
+  "node_modules/postgres-bytea": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+   "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/postgres-date": {
+   "version": "1.0.7",
+   "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+   "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
+  "node_modules/postgres-interval": {
+   "version": "1.2.0",
+   "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+   "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+   "license": "MIT",
+   "dependencies": {
+    "xtend": "^4.0.0"
+   },
+   "engines": {
+    "node": ">=0.10.0"
+   }
+  },
   "node_modules/powershell-utils": {
    "version": "0.1.0",
    "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -8704,6 +9132,28 @@
    },
    "funding": {
     "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/preact": {
+   "version": "10.24.3",
+   "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+   "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+   "license": "MIT",
+   "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/preact"
+   }
+  },
+  "node_modules/preact-render-to-string": {
+   "version": "5.2.6",
+   "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+   "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+   "license": "MIT",
+   "dependencies": {
+    "pretty-format": "^3.8.0"
+   },
+   "peerDependencies": {
+    "preact": ">=10"
    }
   },
   "node_modules/prelude-ls": {
@@ -8729,6 +9179,12 @@
    "funding": {
     "url": "https://github.com/prettier/prettier?sponsor=1"
    }
+  },
+  "node_modules/pretty-format": {
+   "version": "3.8.0",
+   "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+   "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+   "license": "MIT"
   },
   "node_modules/pretty-ms": {
    "version": "9.3.0",
@@ -10365,8 +10821,7 @@
   "node_modules/undici-types": {
    "version": "6.21.0",
    "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-   "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-   "devOptional": true
+   "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
   },
   "node_modules/unicorn-magic": {
    "version": "0.3.0",
@@ -10487,6 +10942,15 @@
    "version": "1.0.2",
    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
    "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+  },
+  "node_modules/uuid": {
+   "version": "8.3.2",
+   "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+   "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+   "license": "MIT",
+   "bin": {
+    "uuid": "dist/bin/uuid"
+   }
   },
   "node_modules/valibot": {
    "version": "1.2.0",
@@ -10705,6 +11169,15 @@
     "url": "https://github.com/sponsors/sindresorhus"
    }
   },
+  "node_modules/xtend": {
+   "version": "4.0.2",
+   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+   "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=0.4"
+   }
+  },
   "node_modules/y18n": {
    "version": "5.0.8",
    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10844,6 +11317,7 @@
    "version": "4.3.6",
    "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
    "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+   "license": "MIT",
    "funding": {
     "url": "https://github.com/sponsors/colinhacks"
    }

--- a/package.json
+++ b/package.json
@@ -12,17 +12,23 @@
   "prepare": "husky"
  },
  "dependencies": {
+  "@auth/prisma-adapter": "^2.11.1",
   "@base-ui/react": "^1.3.0",
+  "@neondatabase/serverless": "^1.0.2",
+  "@prisma/adapter-neon": "^7.5.0",
   "@prisma/client": "^7.5.0",
+  "bcryptjs": "^3.0.3",
   "class-variance-authority": "^0.7.1",
   "clsx": "^2.1.1",
   "lucide-react": "^0.577.0",
   "next": "16.2.0",
+  "next-auth": "^4.24.13",
   "react": "19.2.4",
   "react-dom": "19.2.4",
   "shadcn": "^4.1.0",
   "tailwind-merge": "^3.5.0",
-  "tw-animate-css": "^1.4.0"
+  "tw-animate-css": "^1.4.0",
+  "zod": "^4.3.6"
  },
  "lint-staged": {
   "*.{ts,tsx,js,jsx}": [
@@ -37,12 +43,13 @@
   "@commitlint/cli": "^20.5.0",
   "@commitlint/config-conventional": "^20.5.0",
   "@tailwindcss/postcss": "^4",
+  "@types/bcryptjs": "^2.4.6",
   "@types/node": "^20",
   "@types/react": "^19",
   "@types/react-dom": "^19",
+  "dotenv": "^17.3.1",
   "eslint": "^9",
   "eslint-config-next": "16.2.0",
-  "dotenv": "^17.3.1",
   "eslint-config-prettier": "^10.1.8",
   "husky": "^9.1.7",
   "lint-staged": "^16.4.0",

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/api/blog/[id]/route.ts
+++ b/src/app/api/blog/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { postSchema } from "@/lib/validations";
+import { revalidatePath } from "next/cache";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: Request, { params }: Params) {
+ const { id } = await params;
+ try {
+  const post = await prisma.blogPost.findUnique({ where: { id } });
+  if (!post) return jsonError("Post not found", 404);
+  return NextResponse.json(post);
+ } catch {
+  return jsonError("Failed to fetch post", 500);
+ }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+ const { id } = await params;
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = postSchema.partial().safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const post = await prisma.blogPost.update({
+   where: { id },
+   data: {
+    ...parsed.data,
+    scheduledAt: parsed.data.scheduledAt ? new Date(parsed.data.scheduledAt) : undefined,
+   },
+  });
+
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${post.slug}`);
+  return NextResponse.json(post);
+ } catch {
+  return jsonError("Failed to update post", 500);
+ }
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+ const { id } = await params;
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const post = await prisma.blogPost.delete({ where: { id } });
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${post.slug}`);
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to delete post", 500);
+ }
+}

--- a/src/app/api/blog/[id]/route.ts
+++ b/src/app/api/blog/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, jsonError } from "@/lib/api-utils";
+import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 import { postSchema } from "@/lib/validations";
 import { revalidatePath } from "next/cache";
 
@@ -27,18 +27,26 @@ export async function PUT(request: Request, { params }: Params) {
   const parsed = postSchema.partial().safeParse(body);
   if (!parsed.success) return jsonError("Validation failed", 400);
 
+  const data = { ...parsed.data } as Record<string, unknown>;
+  if ("scheduledAt" in parsed.data) {
+   data.scheduledAt =
+    parsed.data.scheduledAt === null
+     ? null
+     : parsed.data.scheduledAt
+       ? new Date(parsed.data.scheduledAt)
+       : undefined;
+  }
+
   const post = await prisma.blogPost.update({
    where: { id },
-   data: {
-    ...parsed.data,
-    scheduledAt: parsed.data.scheduledAt ? new Date(parsed.data.scheduledAt) : undefined,
-   },
+   data,
   });
 
   revalidatePath("/blog");
   revalidatePath(`/blog/${post.slug}`);
   return NextResponse.json(post);
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("Post not found", 404);
   return jsonError("Failed to update post", 500);
  }
 }
@@ -53,7 +61,8 @@ export async function DELETE(_request: Request, { params }: Params) {
   revalidatePath("/blog");
   revalidatePath(`/blog/${post.slug}`);
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("Post not found", 404);
   return jsonError("Failed to delete post", 500);
  }
 }

--- a/src/app/api/blog/route.ts
+++ b/src/app/api/blog/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { postSchema } from "@/lib/validations";
+import { revalidatePath } from "next/cache";
+
+export async function GET(request: NextRequest) {
+ try {
+  const { searchParams } = request.nextUrl;
+  const status = searchParams.get("status") || "published";
+
+  const posts = await prisma.blogPost.findMany({
+   where: { status },
+   orderBy: { publishedAt: "desc" },
+  });
+
+  return NextResponse.json(posts);
+ } catch {
+  return jsonError("Failed to fetch posts", 500);
+ }
+}
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = postSchema.safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const existing = await prisma.blogPost.findUnique({
+   where: { slug: parsed.data.slug },
+  });
+  if (existing) return jsonError("Slug already exists", 409);
+
+  const post = await prisma.blogPost.create({
+   data: {
+    ...parsed.data,
+    publishedAt: parsed.data.status === "published" ? new Date() : null,
+    scheduledAt: parsed.data.scheduledAt ? new Date(parsed.data.scheduledAt) : null,
+   },
+  });
+
+  revalidatePath("/blog");
+  return NextResponse.json(post, { status: 201 });
+ } catch {
+  return jsonError("Failed to create post", 500);
+ }
+}

--- a/src/app/api/cv/documents/route.ts
+++ b/src/app/api/cv/documents/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+
+export async function GET() {
+ try {
+  const documents = await prisma.cVDocument.findMany({
+   orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(documents);
+ } catch {
+  return jsonError("Failed to fetch CV documents", 500);
+ }
+}
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const { filename, url, publicId, fileSize } = body;
+
+  if (!filename || !url || !publicId || !fileSize) {
+   return jsonError("Missing required fields", 400);
+  }
+
+  const document = await prisma.cVDocument.create({
+   data: { filename, url, publicId, fileSize },
+  });
+
+  return NextResponse.json(document, { status: 201 });
+ } catch {
+  return jsonError("Failed to create CV document", 500);
+ }
+}
+
+export async function PATCH(request: NextRequest) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id) return jsonError("ID is required", 400);
+
+  // Deactivate all, then activate the selected one
+  await prisma.$transaction([
+   prisma.cVDocument.updateMany({ data: { isActive: false } }),
+   prisma.cVDocument.update({
+    where: { id },
+    data: { isActive: true },
+   }),
+  ]);
+
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to toggle CV document status", 500);
+ }
+}
+
+export async function DELETE(request: NextRequest) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id) return jsonError("ID is required", 400);
+
+  await prisma.cVDocument.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to delete CV document", 500);
+ }
+}

--- a/src/app/api/cv/documents/route.ts
+++ b/src/app/api/cv/documents/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, jsonError } from "@/lib/api-utils";
+import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 
 export async function GET() {
  try {
@@ -53,7 +53,8 @@ export async function PATCH(request: NextRequest) {
   ]);
 
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("CV document not found", 404);
   return jsonError("Failed to toggle CV document status", 500);
  }
 }
@@ -69,7 +70,8 @@ export async function DELETE(request: NextRequest) {
   await prisma.cVDocument.delete({ where: { id } });
 
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("CV document not found", 404);
   return jsonError("Failed to delete CV document", 500);
  }
 }

--- a/src/app/api/cv/reorder/route.ts
+++ b/src/app/api/cv/reorder/route.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 const reorderSchema = z.array(
  z.object({
   id: z.string(),
-  order: z.number(),
+  order: z.number().int(),
  })
 );
 

--- a/src/app/api/cv/reorder/route.ts
+++ b/src/app/api/cv/reorder/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const reorderSchema = z.array(
+ z.object({
+  id: z.string(),
+  order: z.number(),
+ })
+);
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = reorderSchema.safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  await prisma.$transaction(
+   parsed.data.map((item) =>
+    prisma.cVSection.update({
+     where: { id: item.id },
+     data: { order: item.order },
+    })
+   )
+  );
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to reorder CV sections", 500);
+ }
+}

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { cvSectionSchema } from "@/lib/validations";
+import { revalidatePath } from "next/cache";
+
+export async function GET(request: NextRequest) {
+ try {
+  const { searchParams } = request.nextUrl;
+  const type = searchParams.get("type");
+
+  const sections = await prisma.cVSection.findMany({
+   where: type ? { type } : undefined,
+   orderBy: [{ type: "asc" }, { order: "asc" }],
+  });
+
+  return NextResponse.json(sections);
+ } catch {
+  return jsonError("Failed to fetch CV sections", 500);
+ }
+}
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = cvSectionSchema.safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const section = await prisma.cVSection.create({ data: parsed.data });
+
+  revalidatePath("/");
+  return NextResponse.json(section, { status: 201 });
+ } catch {
+  return jsonError("Failed to create CV section", 500);
+ }
+}
+
+export async function PUT(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const { id, ...data } = body;
+  if (!id) return jsonError("ID is required", 400);
+
+  const parsed = cvSectionSchema.partial().safeParse(data);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const section = await prisma.cVSection.update({
+   where: { id },
+   data: parsed.data,
+  });
+
+  revalidatePath("/");
+  return NextResponse.json(section);
+ } catch {
+  return jsonError("Failed to update CV section", 500);
+ }
+}
+
+export async function DELETE(request: NextRequest) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id) return jsonError("ID is required", 400);
+
+  await prisma.cVSection.delete({ where: { id } });
+
+  revalidatePath("/");
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to delete CV section", 500);
+ }
+}

--- a/src/app/api/cv/route.ts
+++ b/src/app/api/cv/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, jsonError } from "@/lib/api-utils";
+import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 import { cvSectionSchema } from "@/lib/validations";
 import { revalidatePath } from "next/cache";
 
@@ -57,7 +57,8 @@ export async function PUT(request: Request) {
 
   revalidatePath("/");
   return NextResponse.json(section);
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("CV section not found", 404);
   return jsonError("Failed to update CV section", 500);
  }
 }
@@ -74,7 +75,8 @@ export async function DELETE(request: NextRequest) {
 
   revalidatePath("/");
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("CV section not found", 404);
   return jsonError("Failed to delete CV section", 500);
  }
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { profileUpdateSchema } from "@/lib/validations";
+
+export async function GET() {
+ try {
+  const user = await prisma.user.findFirst({
+   select: {
+    id: true,
+    name: true,
+    email: true,
+    title: true,
+    bio: true,
+    profileImage: true,
+    socialLinks: true,
+   },
+  });
+  return NextResponse.json(user);
+ } catch {
+  return jsonError("Failed to fetch profile", 500);
+ }
+}
+
+export async function PUT(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = profileUpdateSchema.partial().safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const user = await prisma.user.findFirst();
+  if (!user) return jsonError("User not found", 404);
+
+  const updated = await prisma.user.update({
+   where: { id: user.id },
+   data: parsed.data,
+   select: {
+    id: true,
+    name: true,
+    email: true,
+    title: true,
+    bio: true,
+    profileImage: true,
+    socialLinks: true,
+   },
+  });
+
+  return NextResponse.json(updated);
+ } catch {
+  return jsonError("Failed to update profile", 500);
+ }
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { projectSchema } from "@/lib/validations";
+import { revalidatePath } from "next/cache";
+
+type Params = { params: Promise<{ id: string }> };
+
+export async function GET(_request: Request, { params }: Params) {
+ const { id } = await params;
+ try {
+  const project = await prisma.project.findUnique({ where: { id } });
+  if (!project) return jsonError("Project not found", 404);
+  return NextResponse.json(project);
+ } catch {
+  return jsonError("Failed to fetch project", 500);
+ }
+}
+
+export async function PUT(request: Request, { params }: Params) {
+ const { id } = await params;
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = projectSchema.partial().safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const project = await prisma.project.update({
+   where: { id },
+   data: parsed.data,
+  });
+
+  revalidatePath("/");
+  revalidatePath("/projects");
+  return NextResponse.json(project);
+ } catch {
+  return jsonError("Failed to update project", 500);
+ }
+}
+
+export async function DELETE(_request: Request, { params }: Params) {
+ const { id } = await params;
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  await prisma.project.delete({ where: { id } });
+  revalidatePath("/");
+  revalidatePath("/projects");
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to delete project", 500);
+ }
+}

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, jsonError } from "@/lib/api-utils";
+import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 import { projectSchema } from "@/lib/validations";
 import { revalidatePath } from "next/cache";
 
@@ -35,7 +35,8 @@ export async function PUT(request: Request, { params }: Params) {
   revalidatePath("/");
   revalidatePath("/projects");
   return NextResponse.json(project);
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("Project not found", 404);
   return jsonError("Failed to update project", 500);
  }
 }
@@ -50,7 +51,8 @@ export async function DELETE(_request: Request, { params }: Params) {
   revalidatePath("/");
   revalidatePath("/projects");
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("Project not found", 404);
   return jsonError("Failed to delete project", 500);
  }
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { projectSchema } from "@/lib/validations";
+import { revalidatePath } from "next/cache";
+
+export async function GET() {
+ try {
+  const projects = await prisma.project.findMany({
+   orderBy: [{ featured: "desc" }, { order: "asc" }],
+  });
+  return NextResponse.json(projects);
+ } catch {
+  return jsonError("Failed to fetch projects", 500);
+ }
+}
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = projectSchema.safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const existing = await prisma.project.findUnique({
+   where: { slug: parsed.data.slug },
+  });
+  if (existing) return jsonError("Slug already exists", 409);
+
+  const project = await prisma.project.create({ data: parsed.data });
+
+  revalidatePath("/");
+  revalidatePath("/projects");
+  return NextResponse.json(project, { status: 201 });
+ } catch {
+  return jsonError("Failed to create project", 500);
+ }
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { settingsSchema } from "@/lib/validations";
+
+export async function GET() {
+ try {
+  let settings = await prisma.siteSettings.findFirst();
+  if (!settings) {
+   settings = await prisma.siteSettings.create({ data: {} });
+  }
+  return NextResponse.json(settings);
+ } catch {
+  return jsonError("Failed to fetch settings", 500);
+ }
+}
+
+export async function PUT(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = settingsSchema.partial().safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  let settings = await prisma.siteSettings.findFirst();
+  if (!settings) {
+   settings = await prisma.siteSettings.create({ data: parsed.data });
+  } else {
+   settings = await prisma.siteSettings.update({
+    where: { id: settings.id },
+    data: parsed.data,
+   });
+  }
+
+  return NextResponse.json(settings);
+ } catch {
+  return jsonError("Failed to update settings", 500);
+ }
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -5,11 +5,8 @@ import { settingsSchema } from "@/lib/validations";
 
 export async function GET() {
  try {
-  let settings = await prisma.siteSettings.findFirst();
-  if (!settings) {
-   settings = await prisma.siteSettings.create({ data: {} });
-  }
-  return NextResponse.json(settings);
+  const settings = await prisma.siteSettings.findFirst();
+  return NextResponse.json(settings ?? {});
  } catch {
   return jsonError("Failed to fetch settings", 500);
  }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth, jsonError } from "@/lib/api-utils";
+import { createUserSchema } from "@/lib/validations";
+
+export async function GET() {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const users = await prisma.user.findMany({
+   select: { id: true, name: true, email: true, createdAt: true },
+   orderBy: { createdAt: "asc" },
+  });
+  return NextResponse.json(users);
+ } catch {
+  return jsonError("Failed to fetch users", 500);
+ }
+}
+
+export async function POST(request: Request) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const body = await request.json();
+  const parsed = createUserSchema.safeParse(body);
+  if (!parsed.success) return jsonError("Validation failed", 400);
+
+  const existing = await prisma.user.findUnique({
+   where: { email: parsed.data.email },
+  });
+  if (existing) return jsonError("Email already exists", 409);
+
+  let passwordHash: string | undefined;
+  if (parsed.data.password) {
+   const bcrypt = await import("bcryptjs");
+   passwordHash = await bcrypt.hash(parsed.data.password, 12);
+  }
+
+  const user = await prisma.user.create({
+   data: {
+    name: parsed.data.name,
+    email: parsed.data.email,
+    passwordHash,
+   },
+   select: { id: true, name: true, email: true, createdAt: true },
+  });
+
+  return NextResponse.json(user, { status: 201 });
+ } catch {
+  return jsonError("Failed to create user", 500);
+ }
+}
+
+export async function DELETE(request: NextRequest) {
+ const { error } = await requireAuth();
+ if (error) return error;
+
+ try {
+  const id = request.nextUrl.searchParams.get("id");
+  if (!id) return jsonError("ID is required", 400);
+
+  await prisma.user.delete({ where: { id } });
+
+  return NextResponse.json({ success: true });
+ } catch {
+  return jsonError("Failed to delete user", 500);
+ }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { requireAuth, jsonError } from "@/lib/api-utils";
+import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 import { createUserSchema } from "@/lib/validations";
 
 export async function GET() {
@@ -64,7 +64,8 @@ export async function DELETE(request: NextRequest) {
   await prisma.user.delete({ where: { id } });
 
   return NextResponse.json({ success: true });
- } catch {
+ } catch (e) {
+  if (isNotFoundError(e)) return jsonError("User not found", 404);
   return jsonError("Failed to delete user", 500);
  }
 }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,22 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+/**
+ * Returns a consistent JSON error response.
+ */
+export function jsonError(message: string, status: number) {
+ return NextResponse.json({ error: message }, { status });
+}
+
+/**
+ * Checks for an authenticated session.
+ * Returns the session if authenticated, or an error response if not.
+ */
+export async function requireAuth() {
+ const session = await getServerSession(authOptions);
+ if (!session) {
+  return { session: null as never, error: jsonError("Unauthorized", 401) };
+ }
+ return { session, error: null };
+}

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,12 +1,20 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { NextResponse } from "next/server";
+import { Prisma } from "@/generated/prisma";
 
 /**
  * Returns a consistent JSON error response.
  */
 export function jsonError(message: string, status: number) {
  return NextResponse.json({ error: message }, { status });
+}
+
+/**
+ * Checks if a Prisma error is a "record not found" error (P2025).
+ */
+export function isNotFoundError(error: unknown): boolean {
+ return error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025";
 }
 
 /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,112 @@
+import { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import GoogleProvider from "next-auth/providers/google";
+import GitHubProvider from "next-auth/providers/github";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/lib/prisma";
+
+export const authOptions: NextAuthOptions = {
+ adapter: PrismaAdapter(prisma) as NextAuthOptions["adapter"],
+ session: { strategy: "jwt" },
+ pages: {
+  signIn: "/login",
+ },
+ providers: [
+  ...(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
+   ? [
+      GoogleProvider({
+       clientId: process.env.GOOGLE_CLIENT_ID,
+       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      }),
+     ]
+   : []),
+  ...(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET
+   ? [
+      GitHubProvider({
+       clientId: process.env.GITHUB_CLIENT_ID,
+       clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      }),
+     ]
+   : []),
+  CredentialsProvider({
+   name: "Credentials",
+   credentials: {
+    email: { label: "Email", type: "email" },
+    password: { label: "Password", type: "password" },
+   },
+   async authorize(credentials) {
+    if (!credentials?.email || !credentials?.password) return null;
+
+    const user = await prisma.user.findUnique({
+     where: { email: credentials.email },
+    });
+
+    if (!user || !user.passwordHash) return null;
+
+    const valid = await bcrypt.compare(credentials.password, user.passwordHash);
+    if (!valid) return null;
+
+    return { id: user.id, email: user.email, name: user.name };
+   },
+  }),
+ ],
+ callbacks: {
+  async signIn({ user, account, profile }) {
+   if (account?.provider === "credentials") return true;
+
+   const email = user.email ?? (profile as { email?: string })?.email;
+   if (!email || !account) return false;
+
+   const existing = await prisma.user.findUnique({
+    where: { email },
+   });
+   if (!existing) return false;
+
+   // Auto-link OAuth account if not already linked
+   const linked = await prisma.account.findUnique({
+    where: {
+     provider_providerAccountId: {
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+     },
+    },
+   });
+
+   if (!linked) {
+    await prisma.account.create({
+     data: {
+      userId: existing.id,
+      type: account.type,
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+      refresh_token: account.refresh_token as string | undefined,
+      access_token: account.access_token as string | undefined,
+      expires_at: account.expires_at as number | undefined,
+      token_type: account.token_type as string | undefined,
+      scope: account.scope as string | undefined,
+      id_token: account.id_token as string | undefined,
+      session_state: account.session_state as string | undefined,
+     },
+    });
+   }
+
+   return true;
+  },
+  async jwt({ token, user }) {
+   if (user) token.id = user.id;
+
+   if (!token.id && token.email) {
+    const dbUser = await prisma.user.findUnique({
+     where: { email: token.email },
+    });
+    if (dbUser) token.id = dbUser.id;
+   }
+   return token;
+  },
+  session({ session, token }) {
+   if (session.user) session.user.id = token.id as string;
+   return session;
+  },
+ },
+};

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,7 +1,13 @@
 import { PrismaClient } from "@/generated/prisma";
+import { PrismaNeon } from "@prisma/adapter-neon";
 
 const globalForPrisma = globalThis as typeof globalThis & { prisma?: PrismaClient };
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+function createPrismaClient() {
+ const adapter = new PrismaNeon({ connectionString: process.env.DATABASE_URL! });
+ return new PrismaClient({ adapter });
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const profileUpdateSchema = z.object({
+ name: z.string().min(1),
+ title: z.string().optional(),
+ bio: z.string().optional(),
+ profileImage: z.string().optional(),
+ socialLinks: z.record(z.string(), z.string()).optional(),
+});
+
+export const settingsSchema = z.object({
+ siteTitle: z.string().min(1),
+ siteDescription: z.string().optional(),
+ accentColor: z.string().max(7).optional(),
+ logoUrl: z.string().optional(),
+ faviconUrl: z.string().optional(),
+ footerText: z.string().optional(),
+ maintenanceMode: z.boolean().optional(),
+ showBlog: z.boolean().optional(),
+ showProjects: z.boolean().optional(),
+});
+
+export const postSchema = z.object({
+ title: z.string().min(1),
+ slug: z.string().min(1),
+ excerpt: z.string().optional(),
+ content: z.string().min(1),
+ contentHtml: z.string().optional(),
+ coverImageUrl: z.string().optional(),
+ category: z.string().optional(),
+ tags: z.array(z.string()).optional(),
+ status: z.enum(["draft", "published", "archived"]).optional(),
+ scheduledAt: z.string().datetime().optional().nullable(),
+});
+
+export const projectSchema = z.object({
+ title: z.string().min(1),
+ slug: z.string().min(1),
+ description: z.string().optional(),
+ techStack: z.array(z.string()).optional(),
+ liveUrl: z.string().optional(),
+ repoUrl: z.string().optional(),
+ imageUrl: z.string().optional(),
+ featured: z.boolean().optional(),
+ order: z.number().optional(),
+});
+
+export const cvSectionSchema = z.object({
+ type: z.enum(["experience", "education", "skill", "award"]),
+ title: z.string().min(1),
+ subtitle: z.string().optional(),
+ description: z.string().optional(),
+ logoUrl: z.string().optional(),
+ location: z.string().optional(),
+ startDate: z.string().optional(),
+ endDate: z.string().optional(),
+ order: z.number(),
+});
+
+export const createUserSchema = z.object({
+ name: z.string().min(1),
+ email: z.string().email(),
+ password: z.string().min(6).optional(),
+});

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import "next-auth";
+
+declare module "next-auth" {
+ interface Session {
+  user: {
+   id: string;
+   name?: string | null;
+   email?: string | null;
+   image?: string | null;
+  };
+ }
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Create the API routes and server-side logic for managing portfolio content. These routes power the inline editing experience and handle all create, read, update, and delete operations for content entries.

**Changes:**
- Set up API routes for content CRUD operations
- Address copilot review feedback on API routes

**Impact:**
- `.env.example` — Modified (+18, -0)
- `package-lock.json` — Modified (+479, -5)
- `package.json` — Modified (+9, -2)
- `src/app/api/auth/[...nextauth]/route.ts` — Added (+6, -0)
- `src/app/api/blog/[id]/route.ts` — Added (+68, -0)
- `src/app/api/blog/route.ts` — Added (+50, -0)
- `src/app/api/cv/documents/route.ts` — Added (+77, -0)
- `src/app/api/cv/reorder/route.ts` — Added (+37, -0)
- `src/app/api/cv/route.ts` — Added (+82, -0)
- `src/app/api/profile/route.ts` — Added (+55, -0)
- `src/app/api/projects/[id]/route.ts` — Added (+58, -0)
- `src/app/api/projects/route.ts` — Added (+40, -0)
- `src/app/api/settings/route.ts` — Added (+38, -0)
- `src/app/api/users/route.ts` — Added (+71, -0)
- `src/lib/api-utils.ts` — Added (+30, -0)
- `src/lib/auth.ts` — Added (+112, -0)
- `src/lib/prisma.ts` — Modified (+7, -1)
- `src/lib/validations.ts` — Added (+64, -0)
- `src/types/next-auth.d.ts` — Added (+12, -0)

## Linked Issue
**#11** — Set up API routes for content CRUD operations

Closes #11