### PR TITLE
feat(auth): set up NextAuth with login page, auth provider, and inline edit components

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,15 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { AuthProvider } from "@/components/shared/auth-provider";
+import { DrawerStateProvider } from "@/components/shared/drawer-state-provider";
+
+export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+ const session = await getServerSession(authOptions);
+ const isAdmin = !!session;
+
+ return (
+  <AuthProvider isAdmin={isAdmin}>
+   <DrawerStateProvider>{children}</DrawerStateProvider>
+  </AuthProvider>
+ );
+}

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -5,6 +5,7 @@ import { DrawerStateProvider } from "@/components/shared/drawer-state-provider";
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
  const session = await getServerSession(authOptions);
+ // Single-owner portfolio — any authenticated user is the admin
  const isAdmin = !!session;
 
  return (

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+ return (
+  <main className="flex flex-1 items-center justify-center">
+   <h1 className="text-2xl font-semibold">Hello World</h1>
+  </main>
+ );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -39,7 +39,8 @@ function LoginForm() {
   if (result?.error) {
    setError("Invalid email or password");
   } else {
-   router.push(callbackUrl);
+   const targetUrl = result?.url || "/";
+   router.push(targetUrl);
    router.refresh();
   }
  }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export default function LoginPage() {
+ return (
+  <Suspense>
+   <LoginForm />
+  </Suspense>
+ );
+}
+
+function LoginForm() {
+ const router = useRouter();
+ const searchParams = useSearchParams();
+ const callbackUrl = searchParams.get("callbackUrl") || "/";
+ const [email, setEmail] = useState("");
+ const [password, setPassword] = useState("");
+ const [error, setError] = useState("");
+ const [loading, setLoading] = useState(false);
+
+ async function handleSubmit(e: React.FormEvent) {
+  e.preventDefault();
+  setError("");
+  setLoading(true);
+
+  const result = await signIn("credentials", {
+   email,
+   password,
+   redirect: false,
+   callbackUrl,
+  });
+
+  setLoading(false);
+
+  if (result?.error) {
+   setError("Invalid email or password");
+  } else {
+   router.push(callbackUrl);
+   router.refresh();
+  }
+ }
+
+ return (
+  <div className="flex min-h-screen items-center justify-center">
+   <div className="w-full max-w-sm space-y-6 p-6">
+    <h1 className="text-center text-2xl font-bold">Sign In</h1>
+
+    <form onSubmit={handleSubmit} className="space-y-4">
+     <div>
+      <label htmlFor="email" className="block text-sm font-medium">
+       Email
+      </label>
+      <input
+       id="email"
+       type="email"
+       value={email}
+       onChange={(e) => setEmail(e.target.value)}
+       required
+       className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+      />
+     </div>
+
+     <div>
+      <label htmlFor="password" className="block text-sm font-medium">
+       Password
+      </label>
+      <input
+       id="password"
+       type="password"
+       value={password}
+       onChange={(e) => setPassword(e.target.value)}
+       required
+       className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
+      />
+     </div>
+
+     {error && <p className="text-sm text-red-500">{error}</p>}
+
+     <Button type="submit" className="w-full" disabled={loading}>
+      {loading ? "Signing in..." : "Sign In"}
+     </Button>
+    </form>
+   </div>
+  </div>
+ );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,0 @@
-export default function Home() {
-  return (
-    <main className="flex flex-1 items-center justify-center">
-      <h1 className="text-2xl font-semibold">Hello World</h1>
-    </main>
-  );
-}

--- a/src/components/shared/admin-only.tsx
+++ b/src/components/shared/admin-only.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useIsAdmin } from "@/components/shared/auth-provider";
+
+export function AdminOnly({ children }: { children: React.ReactNode }) {
+ const isAdmin = useIsAdmin();
+ if (!isAdmin) return null;
+ return <>{children}</>;
+}

--- a/src/components/shared/auth-provider.tsx
+++ b/src/components/shared/auth-provider.tsx
@@ -22,7 +22,7 @@ export function AuthProvider({
 }) {
  return (
   <SessionProvider>
-   <AuthContext value={{ isAdmin }}>{children}</AuthContext>
+   <AuthContext.Provider value={{ isAdmin }}>{children}</AuthContext.Provider>
   </SessionProvider>
  );
 }

--- a/src/components/shared/auth-provider.tsx
+++ b/src/components/shared/auth-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import { createContext, useContext } from "react";
+
+type AuthContextType = {
+ isAdmin: boolean;
+};
+
+const AuthContext = createContext<AuthContextType>({ isAdmin: false });
+
+export function useIsAdmin() {
+ return useContext(AuthContext).isAdmin;
+}
+
+export function AuthProvider({
+ children,
+ isAdmin,
+}: {
+ children: React.ReactNode;
+ isAdmin: boolean;
+}) {
+ return (
+  <SessionProvider>
+   <AuthContext value={{ isAdmin }}>{children}</AuthContext>
+  </SessionProvider>
+ );
+}

--- a/src/components/shared/drawer-state-provider.tsx
+++ b/src/components/shared/drawer-state-provider.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext, useState, useCallback } from "react";
+
+export type GlobalDrawer =
+ | "settings"
+ | "profile"
+ | "users"
+ | "cv-experience"
+ | "cv-education"
+ | "cv-skill"
+ | "cv-documents";
+
+type DrawerStateContextType = {
+ open: GlobalDrawer | null;
+ openDrawer: (drawer: GlobalDrawer) => void;
+ closeDrawer: () => void;
+};
+
+const DrawerStateContext = createContext<DrawerStateContextType>({
+ open: null,
+ openDrawer: () => {},
+ closeDrawer: () => {},
+});
+
+export function useDrawerState() {
+ return useContext(DrawerStateContext);
+}
+
+export function DrawerStateProvider({ children }: { children: React.ReactNode }) {
+ const [open, setOpen] = useState<GlobalDrawer | null>(null);
+
+ const openDrawer = useCallback((drawer: GlobalDrawer) => {
+  setOpen(drawer);
+ }, []);
+
+ const closeDrawer = useCallback(() => {
+  setOpen(null);
+ }, []);
+
+ return (
+  <DrawerStateContext value={{ open, openDrawer, closeDrawer }}>{children}</DrawerStateContext>
+ );
+}

--- a/src/components/shared/drawer-state-provider.tsx
+++ b/src/components/shared/drawer-state-provider.tsx
@@ -39,6 +39,8 @@ export function DrawerStateProvider({ children }: { children: React.ReactNode })
  }, []);
 
  return (
-  <DrawerStateContext value={{ open, openDrawer, closeDrawer }}>{children}</DrawerStateContext>
+  <DrawerStateContext.Provider value={{ open, openDrawer, closeDrawer }}>
+   {children}
+  </DrawerStateContext.Provider>
  );
 }

--- a/src/components/shared/edit-button.tsx
+++ b/src/components/shared/edit-button.tsx
@@ -17,6 +17,7 @@ export function EditButton({ onClick, className }: EditButtonProps) {
     size="icon"
     onClick={onClick}
     className={`h-8 w-8 rounded-full opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 ${className ?? ""}`}
+    aria-label="Edit"
    >
     <Pencil className="h-4 w-4" />
    </Button>

--- a/src/components/shared/edit-button.tsx
+++ b/src/components/shared/edit-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Pencil } from "lucide-react";
+import { AdminOnly } from "@/components/shared/admin-only";
+import { Button } from "@/components/ui/button";
+
+type EditButtonProps = {
+ onClick: () => void;
+ className?: string;
+};
+
+export function EditButton({ onClick, className }: EditButtonProps) {
+ return (
+  <AdminOnly>
+   <Button
+    variant="ghost"
+    size="icon"
+    onClick={onClick}
+    className={`h-8 w-8 rounded-full opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 ${className ?? ""}`}
+   >
+    <Pencil className="h-4 w-4" />
+   </Button>
+  </AdminOnly>
+ );
+}

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -3,9 +3,10 @@
  * Throws with the server error message on non-OK responses.
  */
 export async function apiFetch<T = unknown>(url: string, options?: RequestInit): Promise<T> {
+ const headers = { "Content-Type": "application/json", ...(options?.headers ?? {}) };
  const response = await fetch(url, {
-  headers: { "Content-Type": "application/json", ...options?.headers },
   ...options,
+  headers,
  });
 
  if (!response.ok) {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,0 +1,17 @@
+/**
+ * Wrapper for authenticated API calls from the client.
+ * Throws with the server error message on non-OK responses.
+ */
+export async function apiFetch<T = unknown>(url: string, options?: RequestInit): Promise<T> {
+ const response = await fetch(url, {
+  headers: { "Content-Type": "application/json", ...options?.headers },
+  ...options,
+ });
+
+ if (!response.ok) {
+  const data = await response.json().catch(() => ({}));
+  throw new Error(data.error || `Request failed (${response.status})`);
+ }
+
+ return response.json();
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Set up NextAuth for admin authentication and implement inline content editing on public pages. Authenticated admins see edit buttons on sections that open Sheet (drawer) components for editing content in place — no separate admin dashboard.

**Changes:**
- Set up NextAuth with login page, auth provider, and inline edit components
- Address copilot review feedback on auth and inline edit components

**Impact:**
- `src/app/(public)/layout.tsx` — Added (+16, -0)
- `src/app/(public)/page.tsx` — Added (+7, -0)
- `src/app/login/page.tsx` — Added (+91, -0)
- `src/app/page.tsx` — Removed (+0, -7)
- `src/components/shared/admin-only.tsx` — Added (+9, -0)
- `src/components/shared/auth-provider.tsx` — Added (+28, -0)
- `src/components/shared/drawer-state-provider.tsx` — Added (+46, -0)
- `src/components/shared/edit-button.tsx` — Added (+26, -0)
- `src/lib/api-client.ts` — Added (+18, -0)

## Linked Issue
**#13** — Set up NextAuth authentication with inline content editing

Closes #13