### PR TITLE
feat(ui): add animated flickering grid background and maintenance screen

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -2,15 +2,43 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { AuthProvider } from "@/components/shared/auth-provider";
 import { DrawerStateProvider } from "@/components/shared/drawer-state-provider";
+import { FlickeringGrid } from "@/components/shared/flickering-grid";
+import { MaintenanceScreen } from "@/components/shared/maintenance-screen";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
 
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
- const session = await getServerSession(authOptions);
+ const [session, settings] = await Promise.all([
+  getServerSession(authOptions),
+  prisma.siteSettings.findFirst(),
+ ]);
+
  // Single-owner portfolio — any authenticated user is the admin
  const isAdmin = !!session;
+ const inMaintenance = !isAdmin && (settings?.maintenanceMode ?? false);
+
+ if (inMaintenance) return <MaintenanceScreen />;
 
  return (
   <AuthProvider isAdmin={isAdmin}>
-   <DrawerStateProvider>{children}</DrawerStateProvider>
+   <DrawerStateProvider>
+    <div className="relative min-h-screen overflow-x-clip">
+     {/* Flickering grid background — fades downward */}
+     <div className="absolute inset-0 top-0 left-0 right-0 h-25 overflow-hidden z-0 pointer-events-none">
+      <FlickeringGrid
+       className="h-full w-full"
+       squareSize={2}
+       gridGap={2}
+       style={{
+        maskImage: "linear-gradient(to bottom, black, transparent)",
+        WebkitMaskImage: "linear-gradient(to bottom, black, transparent)",
+       }}
+      />
+     </div>
+     <div className="relative z-10">{children}</div>
+    </div>
+   </DrawerStateProvider>
   </AuthProvider>
  );
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -11,7 +11,9 @@ export const dynamic = "force-dynamic";
 export default async function PublicLayout({ children }: { children: React.ReactNode }) {
  const [session, settings] = await Promise.all([
   getServerSession(authOptions),
-  prisma.siteSettings.findFirst(),
+  prisma.siteSettings.findFirst({
+   select: { maintenanceMode: true },
+  }),
  ]);
 
  // Single-owner portfolio — any authenticated user is the admin
@@ -25,7 +27,7 @@ export default async function PublicLayout({ children }: { children: React.React
    <DrawerStateProvider>
     <div className="relative min-h-screen overflow-x-clip">
      {/* Flickering grid background — fades downward */}
-     <div className="absolute inset-0 top-0 left-0 right-0 h-25 overflow-hidden z-0 pointer-events-none">
+     <div className="absolute inset-x-0 top-0 h-24 overflow-hidden z-0 pointer-events-none">
       <FlickeringGrid
        className="h-full w-full"
        squareSize={2}

--- a/src/components/shared/flickering-grid.tsx
+++ b/src/components/shared/flickering-grid.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from "react";
 
+const DEFAULT_COLORS = ["#0DFFF7", "#0BC5BF"];
+
 interface FlickeringGridProps {
  className?: string;
  squareSize?: number;
@@ -18,7 +20,7 @@ export function FlickeringGrid({
  gridGap = 7,
  flickerChance = 0.025,
  maxOpacity = 0.12,
- colors = ["#6AFF5E", "#0DFFF7"],
+ colors = DEFAULT_COLORS,
  style,
 }: FlickeringGridProps) {
  const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -36,10 +38,13 @@ export function FlickeringGrid({
   let animId: number;
 
   const init = () => {
-   canvas.width = canvas.offsetWidth;
-   canvas.height = canvas.offsetHeight;
-   cols = Math.ceil(canvas.width / (squareSize + gridGap));
-   rows = Math.ceil(canvas.height / (squareSize + gridGap));
+   const dpr = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
+   const rect = canvas.getBoundingClientRect();
+   canvas.width = rect.width * dpr;
+   canvas.height = rect.height * dpr;
+   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+   cols = Math.ceil(rect.width / (squareSize + gridGap));
+   rows = Math.ceil(rect.height / (squareSize + gridGap));
    const total = cols * rows;
    opacities.length = 0;
    colorIndices.length = 0;
@@ -82,5 +87,13 @@ export function FlickeringGrid({
   };
  }, [squareSize, gridGap, flickerChance, maxOpacity, colors]);
 
- return <canvas ref={canvasRef} className={`block ${className}`} style={style} />;
+ return (
+  <canvas
+   ref={canvasRef}
+   className={`block ${className}`}
+   style={style}
+   aria-hidden="true"
+   role="presentation"
+  />
+ );
 }

--- a/src/components/shared/flickering-grid.tsx
+++ b/src/components/shared/flickering-grid.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface FlickeringGridProps {
+ className?: string;
+ squareSize?: number;
+ gridGap?: number;
+ flickerChance?: number;
+ maxOpacity?: number;
+ colors?: string[];
+ style?: React.CSSProperties;
+}
+
+export function FlickeringGrid({
+ className = "",
+ squareSize = 3,
+ gridGap = 7,
+ flickerChance = 0.025,
+ maxOpacity = 0.12,
+ colors = ["#6AFF5E", "#0DFFF7"],
+ style,
+}: FlickeringGridProps) {
+ const canvasRef = useRef<HTMLCanvasElement>(null);
+
+ useEffect(() => {
+  const canvas = canvasRef.current;
+  if (!canvas) return;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const opacities: number[] = [];
+  const colorIndices: number[] = [];
+  let cols = 0;
+  let rows = 0;
+  let animId: number;
+
+  const init = () => {
+   canvas.width = canvas.offsetWidth;
+   canvas.height = canvas.offsetHeight;
+   cols = Math.ceil(canvas.width / (squareSize + gridGap));
+   rows = Math.ceil(canvas.height / (squareSize + gridGap));
+   const total = cols * rows;
+   opacities.length = 0;
+   colorIndices.length = 0;
+   for (let i = 0; i < total; i++) {
+    opacities.push(Math.random() * maxOpacity);
+    colorIndices.push(Math.floor(Math.random() * colors.length));
+   }
+  };
+
+  const draw = () => {
+   ctx.clearRect(0, 0, canvas.width, canvas.height);
+   for (let i = 0; i < opacities.length; i++) {
+    if (Math.random() < flickerChance) {
+     opacities[i] = Math.random() * maxOpacity;
+     colorIndices[i] = Math.floor(Math.random() * colors.length);
+    }
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    ctx.globalAlpha = opacities[i];
+    ctx.fillStyle = colors[colorIndices[i]];
+    ctx.fillRect(
+     col * (squareSize + gridGap),
+     row * (squareSize + gridGap),
+     squareSize,
+     squareSize
+    );
+   }
+   ctx.globalAlpha = 1;
+   animId = requestAnimationFrame(draw);
+  };
+
+  const ro = new ResizeObserver(init);
+  ro.observe(canvas);
+  init();
+  draw();
+
+  return () => {
+   ro.disconnect();
+   cancelAnimationFrame(animId);
+  };
+ }, [squareSize, gridGap, flickerChance, maxOpacity, colors]);
+
+ return <canvas ref={canvasRef} className={`block ${className}`} style={style} />;
+}

--- a/src/components/shared/maintenance-screen.tsx
+++ b/src/components/shared/maintenance-screen.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { FlickeringGrid } from "@/components/shared/flickering-grid";
+
+export function MaintenanceScreen() {
+ return (
+  <div className="relative flex min-h-screen items-center justify-center bg-neutral-950">
+   <div className="absolute inset-0 pointer-events-none">
+    <FlickeringGrid
+     className="h-full w-full"
+     squareSize={3}
+     gridGap={7}
+     style={{
+      maskImage: "radial-gradient(ellipse 60% 60% at 50% 50%, transparent 30%, black 100%)",
+      WebkitMaskImage: "radial-gradient(ellipse 60% 60% at 50% 50%, transparent 30%, black 100%)",
+     }}
+    />
+   </div>
+   <div className="relative z-10 text-center">
+    <h1 className="text-4xl font-bold text-white">Under Maintenance</h1>
+    <p className="mt-2 text-neutral-400">We&apos;ll be back shortly.</p>
+   </div>
+  </div>
+ );
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build a canvas-based animated flickering grid background that renders at the top of the page with a downward fade. The grid creates a subtle, performant visual effect behind the page content.

**Changes:**
- Add animated flickering grid background and maintenance screen
- Address review feedback on flickering grid and layout

**Impact:**
- `src/app/(public)/layout.tsx` — Modified (+32, -2)
- `src/components/shared/flickering-grid.tsx` — Added (+99, -0)
- `src/components/shared/maintenance-screen.tsx` — Added (+25, -0)

## Linked Issue
**#23** — Build animated flickering grid background

Closes #23