### PR TITLE
feat(ui): add hero section with avatar, about, social links, and resume download

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -16,7 +16,16 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function HomePage() {
  const [user, activeCV] = await Promise.all([
-  prisma.user.findFirst({ orderBy: { createdAt: "asc" } }),
+  prisma.user.findFirst({
+   orderBy: { createdAt: "asc" },
+   select: {
+    name: true,
+    title: true,
+    bio: true,
+    profileImage: true,
+    socialLinks: true,
+   },
+  }),
   prisma.cVDocument.findFirst({
    where: { isActive: true },
    select: { id: true },
@@ -25,14 +34,14 @@ export default async function HomePage() {
 
  if (!user) {
   return (
-   <main className="min-h-dvh flex flex-col gap-14 max-w-2xl mx-auto px-6 w-full py-16 md:py-24">
-    <HeroSection
-     name={"Nathalie"}
-     title={"Frontend Developer"}
-     bio={
-      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita placeat illo dolorum quasi, repellendus magni quam eius amet harum neque?"
-     }
-    />
+   <main className="min-h-dvh flex flex-col items-center justify-center max-w-2xl mx-auto px-6 w-full">
+    <div className="space-y-4 text-center">
+     <h1 className="text-3xl font-semibold tracking-tight">Site not configured yet</h1>
+     <p className="text-neutral-500 dark:text-neutral-400">
+      This portfolio has not been set up. Please sign in to the admin area and create your profile
+      to make your site publicly visible.
+     </p>
+    </div>
    </main>
   );
  }

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,7 +1,54 @@
-export default function Home() {
+import { prisma } from "@/lib/prisma";
+import { HeroSection } from "@/components/section/hero-section";
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(): Promise<Metadata> {
+ const settings = await prisma.siteSettings.findFirst({
+  select: { siteTitle: true, siteDescription: true },
+ });
+ return {
+  title: settings?.siteTitle ?? "Portfolio",
+  description: settings?.siteDescription ?? "Personal portfolio",
+ };
+}
+
+export default async function HomePage() {
+ const [user, activeCV] = await Promise.all([
+  prisma.user.findFirst({ orderBy: { createdAt: "asc" } }),
+  prisma.cVDocument.findFirst({
+   where: { isActive: true },
+   select: { id: true },
+  }),
+ ]);
+
+ if (!user) {
+  return (
+   <main className="min-h-dvh flex flex-col gap-14 max-w-2xl mx-auto px-6 w-full py-16 md:py-24">
+    <HeroSection
+     name={"Nathalie"}
+     title={"Frontend Developer"}
+     bio={
+      "Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita placeat illo dolorum quasi, repellendus magni quam eius amet harum neque?"
+     }
+    />
+   </main>
+  );
+ }
+
+ const socialLinks = user.socialLinks as Record<string, string> | null;
+
  return (
-  <main className="flex flex-1 items-center justify-center">
-   <h1 className="text-2xl font-semibold">Hello World</h1>
+  <main className="min-h-dvh flex flex-col gap-14 max-w-2xl mx-auto px-6 w-full py-16 md:py-24">
+   <HeroSection
+    name={user.name}
+    title={user.title ?? "Developer"}
+    bio={user.bio ?? ""}
+    profileImage={user.profileImage}
+    socialLinks={socialLinks}
+    hasActiveCV={!!activeCV}
+   />
   </main>
  );
 }

--- a/src/components/layout/dock-nav.tsx
+++ b/src/components/layout/dock-nav.tsx
@@ -129,16 +129,13 @@ export function DockNav({ socialLinks, hasActiveCV, isAdmin, pageVisibility }: D
       className="h-2/3 m-auto w-px bg-neutral-200 dark:bg-neutral-800"
      />
      <Tooltip>
-      <TooltipTrigger>
-       <button
-        type="button"
-        onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-        aria-label="Toggle theme"
-       >
-        <DockIcon className={DOCK_ICON_CLASS}>
-         {resolvedTheme === "dark" ? <Sun className="size-full" /> : <Moon className="size-full" />}
-        </DockIcon>
-       </button>
+      <TooltipTrigger
+       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+       aria-label="Toggle theme"
+      >
+       <DockIcon className={DOCK_ICON_CLASS}>
+        {resolvedTheme === "dark" ? <Sun className="size-full" /> : <Moon className="size-full" />}
+       </DockIcon>
       </TooltipTrigger>
       <TooltipContent side="bottom" sideOffset={8} className={DOCK_TOOLTIP_CLASS}>
        <p>Theme</p>

--- a/src/components/section/hero-section.tsx
+++ b/src/components/section/hero-section.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { FileDown } from "lucide-react";
+import Link from "next/link";
+import { EditButton } from "@/components/shared/edit-button";
+import { useDrawerState } from "@/components/shared/drawer-state-provider";
+
+interface HeroSectionProps {
+ name: string;
+ title: string;
+ bio: string;
+ profileImage?: string | null;
+ socialLinks?: Record<string, string> | null;
+ hasActiveCV?: boolean;
+}
+
+export function HeroSection({
+ name,
+ title,
+ bio,
+ profileImage,
+ socialLinks,
+ hasActiveCV,
+}: HeroSectionProps) {
+ const { openDrawer } = useDrawerState();
+ const initials = name
+  .split(" ")
+  .map((n) => n[0])
+  .join("")
+  .toUpperCase()
+  .slice(0, 2);
+
+ return (
+  <>
+   {/* ── Hero ── */}
+   <section id="hero" className="group">
+    <div className="flex flex-col items-center gap-2 md:flex-row md:items-start md:justify-between lg:gap-6">
+     {/* Text — centered on mobile, left-aligned on desktop */}
+     <div className="order-2 flex flex-col items-center gap-2 text-center md:order-1 md:items-start md:text-left">
+      <div className="flex items-center gap-2">
+       <h1 className="text-3xl font-semibold tracking-tighter sm:text-4xl lg:text-5xl">
+        Hi, I&apos;m{" "}
+        <span className="bg-gradient-to-r from-[#0DFFF7] to-[#0BC5BF] bg-clip-text text-transparent">
+         {name}
+        </span>
+       </h1>
+       <EditButton onClick={() => openDrawer("profile")} />
+      </div>
+      <p className="max-w-[600px] text-neutral-500 dark:text-neutral-400 md:text-lg lg:text-xl">
+       {title}
+      </p>
+     </div>
+
+     {/* Avatar — on top for mobile, right for desktop */}
+     <div className="order-1 md:order-2">
+      <Avatar className="size-24 border shadow-lg ring-4 ring-neutral-200 dark:ring-neutral-800 md:size-32">
+       <AvatarImage alt={name} src={profileImage ?? ""} />
+       <AvatarFallback className="text-lg font-semibold">{initials}</AvatarFallback>
+      </Avatar>
+     </div>
+    </div>
+   </section>
+
+   {/* ── About ── */}
+   <section id="about" className="group">
+    <div className="flex flex-col gap-y-4">
+     <div className="flex items-center justify-center gap-2 md:justify-start">
+      <h2 className="text-xl font-bold">About</h2>
+      <EditButton onClick={() => openDrawer("profile")} />
+     </div>
+     <div className="prose max-w-full text-pretty leading-relaxed text-neutral-600 dark:text-neutral-300 text-center md:text-left">
+      <p>{bio}</p>
+     </div>
+    </div>
+   </section>
+
+   {/* ── Social links + Resume ── */}
+   <section id="connect" className="group">
+    <div className="flex items-center justify-center gap-3 md:justify-start">
+     {socialLinks?.github && (
+      <Link
+       href={socialLinks.github}
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="GitHub"
+       className="rounded-full p-2 text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+      >
+       <svg className="size-5" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+       </svg>
+      </Link>
+     )}
+     {socialLinks?.linkedin && (
+      <Link
+       href={socialLinks.linkedin}
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="LinkedIn"
+       className="rounded-full p-2 text-neutral-500 transition-colors hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100"
+      >
+       <svg className="size-5" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+       </svg>
+      </Link>
+     )}
+     {hasActiveCV && (
+      <Link
+       href="/api/cv/pdf"
+       target="_blank"
+       rel="noopener noreferrer"
+       className="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+      >
+       <FileDown className="size-4" />
+       Download Resume
+      </Link>
+     )}
+    </div>
+   </section>
+  </>
+ );
+}

--- a/src/components/section/hero-section.tsx
+++ b/src/components/section/hero-section.tsx
@@ -41,13 +41,13 @@ export function HeroSection({
       <div className="flex items-center gap-2">
        <h1 className="text-3xl font-semibold tracking-tighter sm:text-4xl lg:text-5xl">
         Hi, I&apos;m{" "}
-        <span className="bg-gradient-to-r from-[#0DFFF7] to-[#0BC5BF] bg-clip-text text-transparent">
+        <span className="bg-linear-to-r from-[#0DFFF7] to-[#0BC5BF] bg-clip-text text-transparent">
          {name}
         </span>
        </h1>
        <EditButton onClick={() => openDrawer("profile")} />
       </div>
-      <p className="max-w-[600px] text-neutral-500 dark:text-neutral-400 md:text-lg lg:text-xl">
+      <p className="max-w-150 text-neutral-500 dark:text-neutral-400 md:text-lg lg:text-xl">
        {title}
       </p>
      </div>
@@ -55,7 +55,7 @@ export function HeroSection({
      {/* Avatar — on top for mobile, right for desktop */}
      <div className="order-1 md:order-2">
       <Avatar className="size-24 border shadow-lg ring-4 ring-neutral-200 dark:ring-neutral-800 md:size-32">
-       <AvatarImage alt={name} src={profileImage ?? ""} />
+       <AvatarImage alt={name} src={profileImage ?? undefined} />
        <AvatarFallback className="text-lg font-semibold">{initials}</AvatarFallback>
       </Avatar>
      </div>
@@ -69,7 +69,7 @@ export function HeroSection({
       <h2 className="text-xl font-bold">About</h2>
       <EditButton onClick={() => openDrawer("profile")} />
      </div>
-     <div className="prose max-w-full text-pretty leading-relaxed text-neutral-600 dark:text-neutral-300 text-center md:text-left">
+     <div className="max-w-full text-pretty leading-relaxed text-neutral-600 dark:text-neutral-300 text-center md:text-left">
       <p>{bio}</p>
      </div>
     </div>
@@ -106,7 +106,7 @@ export function HeroSection({
      )}
      {hasActiveCV && (
       <Link
-       href="/api/cv/pdf"
+       href="/api/cv"
        target="_blank"
        rel="noopener noreferrer"
        className="inline-flex items-center gap-2 rounded-full border border-neutral-200 px-4 py-2 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"

--- a/src/components/shared/admin-dock-items.tsx
+++ b/src/components/shared/admin-dock-items.tsx
@@ -19,12 +19,10 @@ export function AdminDockItems() {
    />
 
    <Tooltip>
-    <TooltipTrigger>
-     <button type="button" onClick={() => openDrawer("settings")} aria-label="Settings">
-      <DockIcon className={DOCK_ICON_CLASS}>
-       <Settings className="size-full" />
-      </DockIcon>
-     </button>
+    <TooltipTrigger onClick={() => openDrawer("settings")} aria-label="Settings">
+     <DockIcon className={DOCK_ICON_CLASS}>
+      <Settings className="size-full" />
+     </DockIcon>
     </TooltipTrigger>
     <TooltipContent side="bottom" sideOffset={8} className={DOCK_TOOLTIP_CLASS}>
      <p>Settings</p>
@@ -32,12 +30,10 @@ export function AdminDockItems() {
    </Tooltip>
 
    <Tooltip>
-    <TooltipTrigger>
-     <button type="button" onClick={() => signOut({ callbackUrl: "/" })} aria-label="Sign out">
-      <DockIcon className={DOCK_ICON_CLASS}>
-       <LogOut className="size-full" />
-      </DockIcon>
-     </button>
+    <TooltipTrigger onClick={() => signOut({ callbackUrl: "/" })} aria-label="Sign out">
+     <DockIcon className={DOCK_ICON_CLASS}>
+      <LogOut className="size-full" />
+     </DockIcon>
     </TooltipTrigger>
     <TooltipContent side="bottom" sideOffset={8} className={DOCK_TOOLTIP_CLASS}>
      <p>Sign out</p>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import * as React from "react";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+
+import { cn } from "@/lib/utils";
+
+function Avatar({
+ className,
+ size = "default",
+ ...props
+}: AvatarPrimitive.Root.Props & {
+ size?: "default" | "sm" | "lg";
+}) {
+ return (
+  <AvatarPrimitive.Root
+   data-slot="avatar"
+   data-size={size}
+   className={cn(
+    "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+ return (
+  <AvatarPrimitive.Image
+   data-slot="avatar-image"
+   className={cn("aspect-square size-full rounded-full object-cover", className)}
+   {...props}
+  />
+ );
+}
+
+function AvatarFallback({ className, ...props }: AvatarPrimitive.Fallback.Props) {
+ return (
+  <AvatarPrimitive.Fallback
+   data-slot="avatar-fallback"
+   className={cn(
+    "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+ return (
+  <span
+   data-slot="avatar-badge"
+   className={cn(
+    "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+    "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+    "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+    "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div
+   data-slot="avatar-group"
+   className={cn(
+    "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div
+   data-slot="avatar-group-count"
+   className={cn(
+    "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+export { Avatar, AvatarImage, AvatarFallback, AvatarGroup, AvatarGroupCount, AvatarBadge };


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Hero section as the landing component of the portfolio site, displaying name, title, bio, social links, and a download resume button using shadcn/ui and Tailwind CSS. Layout should account for the top-floating dock navigation.

**Changes:**
- Add hero section with avatar, about, social links, and resume download
- Address review feedback on hero section and homepage

**Impact:**
- `src/app/(public)/page.tsx` — Modified (+59, -3)
- `src/components/layout/dock-nav.tsx` — Modified (+7, -10)
- `src/components/section/hero-section.tsx` — Added (+122, -0)
- `src/components/shared/admin-dock-items.tsx` — Modified (+8, -12)
- `src/components/ui/avatar.tsx` — Added (+93, -0)

## Linked Issue
**#14** — Build Hero section component

Closes #14