### PR TITLE
feat(ui): add work experience section with accordion layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
     "next": "^16.2.1",
     "next-auth": "^4.24.13",
     "next-themes": "^0.4.6",
+    "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.0",
@@ -2604,6 +2605,1504 @@
     "react-dom": "^18.0.0 || ^19.0.0"
    }
   },
+  "node_modules/@radix-ui/number": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+   "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+   "license": "MIT"
+  },
+  "node_modules/@radix-ui/primitive": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+   "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+   "license": "MIT"
+  },
+  "node_modules/@radix-ui/react-accessible-icon": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+   "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-visually-hidden": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-accordion": {
+   "version": "1.2.12",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+   "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collapsible": "1.1.12",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-alert-dialog": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+   "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dialog": "1.1.15",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-arrow": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+   "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-aspect-ratio": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+   "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-avatar": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+   "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-is-hydrated": "0.1.0",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-checkbox": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+   "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collapsible": {
+   "version": "1.1.12",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+   "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-collection": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+   "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-compose-refs": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+   "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context": {
+   "version": "1.1.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+   "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-context-menu": {
+   "version": "2.2.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+   "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-menu": "2.1.16",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dialog": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+   "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-focus-guards": "1.1.3",
+    "@radix-ui/react-focus-scope": "1.1.7",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.6.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-direction": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+   "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dismissable-layer": {
+   "version": "1.1.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+   "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-escape-keydown": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-dropdown-menu": {
+   "version": "2.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+   "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-menu": "2.1.16",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-guards": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+   "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-focus-scope": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+   "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-form": {
+   "version": "0.1.8",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+   "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-label": "2.1.7",
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-hover-card": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+   "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-id": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+   "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-label": {
+   "version": "2.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+   "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-menu": {
+   "version": "2.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+   "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-focus-guards": "1.1.3",
+    "@radix-ui/react-focus-scope": "1.1.7",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.6.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-menubar": {
+   "version": "1.1.16",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+   "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-menu": "2.1.16",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-navigation-menu": {
+   "version": "1.2.14",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+   "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-visually-hidden": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-one-time-password-field": {
+   "version": "0.1.8",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+   "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.1",
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-effect-event": "0.0.2",
+    "@radix-ui/react-use-is-hydrated": "0.1.0",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-password-toggle-field": {
+   "version": "0.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+   "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-effect-event": "0.0.2",
+    "@radix-ui/react-use-is-hydrated": "0.1.0"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popover": {
+   "version": "1.1.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+   "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-focus-guards": "1.1.3",
+    "@radix-ui/react-focus-scope": "1.1.7",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.6.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-popper": {
+   "version": "1.2.8",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+   "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+   "license": "MIT",
+   "dependencies": {
+    "@floating-ui/react-dom": "^2.0.0",
+    "@radix-ui/react-arrow": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-use-rect": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1",
+    "@radix-ui/rect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-portal": {
+   "version": "1.1.9",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+   "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-presence": {
+   "version": "1.1.5",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+   "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-primitive": {
+   "version": "2.1.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+   "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-slot": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-progress": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+   "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-radio-group": {
+   "version": "1.3.8",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+   "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-roving-focus": {
+   "version": "1.1.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+   "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-scroll-area": {
+   "version": "1.2.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+   "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.1",
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-select": {
+   "version": "2.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+   "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.1",
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-focus-guards": "1.1.3",
+    "@radix-ui/react-focus-scope": "1.1.7",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-visually-hidden": "1.2.3",
+    "aria-hidden": "^1.2.4",
+    "react-remove-scroll": "^2.6.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-separator": {
+   "version": "1.1.7",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+   "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slider": {
+   "version": "1.3.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+   "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/number": "1.1.1",
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-slot": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+   "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-compose-refs": "1.1.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-switch": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+   "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-previous": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-tabs": {
+   "version": "1.1.13",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+   "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toast": {
+   "version": "1.2.15",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+   "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-visually-hidden": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle": {
+   "version": "1.1.10",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+   "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toggle-group": {
+   "version": "1.1.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+   "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-toggle": "1.1.10",
+    "@radix-ui/react-use-controllable-state": "1.2.2"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-toolbar": {
+   "version": "1.1.11",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+   "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-separator": "1.1.7",
+    "@radix-ui/react-toggle-group": "1.1.11"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-tooltip": {
+   "version": "1.2.8",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+   "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-id": "1.1.1",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-visually-hidden": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-callback-ref": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+   "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-controllable-state": {
+   "version": "1.2.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+   "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-effect-event": "0.0.2",
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-effect-event": {
+   "version": "0.0.2",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+   "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-escape-keydown": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+   "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-callback-ref": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-is-hydrated": {
+   "version": "0.1.0",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+   "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+   "license": "MIT",
+   "dependencies": {
+    "use-sync-external-store": "^1.5.0"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-layout-effect": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+   "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-previous": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+   "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+   "license": "MIT",
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-rect": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+   "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/rect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-use-size": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+   "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-use-layout-effect": "1.1.1"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/react-visually-hidden": {
+   "version": "1.2.3",
+   "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+   "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/react-primitive": "2.1.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/@radix-ui/rect": {
+   "version": "1.1.1",
+   "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+   "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+   "license": "MIT"
+  },
   "node_modules/@rtsao/scc": {
    "version": "1.1.0",
    "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3068,7 +4567,7 @@
    "version": "19.2.3",
    "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
    "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-   "dev": true,
+   "devOptional": true,
    "peerDependencies": {
     "@types/react": "^19.2.0"
    }
@@ -3749,6 +5248,18 @@
    "version": "2.0.1",
    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+  },
+  "node_modules/aria-hidden": {
+   "version": "1.2.6",
+   "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+   "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   }
   },
   "node_modules/aria-query": {
    "version": "5.3.2",
@@ -4902,6 +6413,12 @@
    "engines": {
     "node": ">=8"
    }
+  },
+  "node_modules/detect-node-es": {
+   "version": "1.1.0",
+   "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+   "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+   "license": "MIT"
   },
   "node_modules/diff": {
    "version": "8.0.3",
@@ -6239,6 +7756,15 @@
    },
    "funding": {
     "url": "https://github.com/sponsors/ljharb"
+   }
+  },
+  "node_modules/get-nonce": {
+   "version": "1.0.1",
+   "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+   "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
    }
   },
   "node_modules/get-own-enumerable-keys": {
@@ -9449,6 +10975,83 @@
     }
    ]
   },
+  "node_modules/radix-ui": {
+   "version": "1.4.3",
+   "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+   "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+   "license": "MIT",
+   "dependencies": {
+    "@radix-ui/primitive": "1.1.3",
+    "@radix-ui/react-accessible-icon": "1.1.7",
+    "@radix-ui/react-accordion": "1.2.12",
+    "@radix-ui/react-alert-dialog": "1.1.15",
+    "@radix-ui/react-arrow": "1.1.7",
+    "@radix-ui/react-aspect-ratio": "1.1.7",
+    "@radix-ui/react-avatar": "1.1.10",
+    "@radix-ui/react-checkbox": "1.3.3",
+    "@radix-ui/react-collapsible": "1.1.12",
+    "@radix-ui/react-collection": "1.1.7",
+    "@radix-ui/react-compose-refs": "1.1.2",
+    "@radix-ui/react-context": "1.1.2",
+    "@radix-ui/react-context-menu": "2.2.16",
+    "@radix-ui/react-dialog": "1.1.15",
+    "@radix-ui/react-direction": "1.1.1",
+    "@radix-ui/react-dismissable-layer": "1.1.11",
+    "@radix-ui/react-dropdown-menu": "2.1.16",
+    "@radix-ui/react-focus-guards": "1.1.3",
+    "@radix-ui/react-focus-scope": "1.1.7",
+    "@radix-ui/react-form": "0.1.8",
+    "@radix-ui/react-hover-card": "1.1.15",
+    "@radix-ui/react-label": "2.1.7",
+    "@radix-ui/react-menu": "2.1.16",
+    "@radix-ui/react-menubar": "1.1.16",
+    "@radix-ui/react-navigation-menu": "1.2.14",
+    "@radix-ui/react-one-time-password-field": "0.1.8",
+    "@radix-ui/react-password-toggle-field": "0.1.3",
+    "@radix-ui/react-popover": "1.1.15",
+    "@radix-ui/react-popper": "1.2.8",
+    "@radix-ui/react-portal": "1.1.9",
+    "@radix-ui/react-presence": "1.1.5",
+    "@radix-ui/react-primitive": "2.1.3",
+    "@radix-ui/react-progress": "1.1.7",
+    "@radix-ui/react-radio-group": "1.3.8",
+    "@radix-ui/react-roving-focus": "1.1.11",
+    "@radix-ui/react-scroll-area": "1.2.10",
+    "@radix-ui/react-select": "2.2.6",
+    "@radix-ui/react-separator": "1.1.7",
+    "@radix-ui/react-slider": "1.3.6",
+    "@radix-ui/react-slot": "1.2.3",
+    "@radix-ui/react-switch": "1.2.6",
+    "@radix-ui/react-tabs": "1.1.13",
+    "@radix-ui/react-toast": "1.2.15",
+    "@radix-ui/react-toggle": "1.1.10",
+    "@radix-ui/react-toggle-group": "1.1.11",
+    "@radix-ui/react-toolbar": "1.1.11",
+    "@radix-ui/react-tooltip": "1.2.8",
+    "@radix-ui/react-use-callback-ref": "1.1.1",
+    "@radix-ui/react-use-controllable-state": "1.2.2",
+    "@radix-ui/react-use-effect-event": "0.0.2",
+    "@radix-ui/react-use-escape-keydown": "1.1.1",
+    "@radix-ui/react-use-is-hydrated": "0.1.0",
+    "@radix-ui/react-use-layout-effect": "1.1.1",
+    "@radix-ui/react-use-size": "1.1.1",
+    "@radix-ui/react-visually-hidden": "1.2.3"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "@types/react-dom": "*",
+    "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+    "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    },
+    "@types/react-dom": {
+     "optional": true
+    }
+   }
+  },
   "node_modules/range-parser": {
    "version": "1.2.1",
    "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -9506,6 +11109,75 @@
    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
    "dev": true
+  },
+  "node_modules/react-remove-scroll": {
+   "version": "2.7.2",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+   "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-remove-scroll-bar": "^2.3.7",
+    "react-style-singleton": "^2.2.3",
+    "tslib": "^2.1.0",
+    "use-callback-ref": "^1.3.3",
+    "use-sidecar": "^1.1.3"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-remove-scroll-bar": {
+   "version": "2.3.8",
+   "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+   "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+   "license": "MIT",
+   "dependencies": {
+    "react-style-singleton": "^2.2.2",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/react-style-singleton": {
+   "version": "2.2.3",
+   "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+   "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+   "license": "MIT",
+   "dependencies": {
+    "get-nonce": "^1.0.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
   },
   "node_modules/readdirp": {
    "version": "4.1.2",
@@ -11022,6 +12694,49 @@
    "dev": true,
    "dependencies": {
     "punycode": "^2.1.0"
+   }
+  },
+  "node_modules/use-callback-ref": {
+   "version": "1.3.3",
+   "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+   "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+   "license": "MIT",
+   "dependencies": {
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
+   }
+  },
+  "node_modules/use-sidecar": {
+   "version": "1.1.3",
+   "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+   "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+   "license": "MIT",
+   "dependencies": {
+    "detect-node-es": "^1.1.0",
+    "tslib": "^2.0.0"
+   },
+   "engines": {
+    "node": ">=10"
+   },
+   "peerDependencies": {
+    "@types/react": "*",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+   },
+   "peerDependenciesMeta": {
+    "@types/react": {
+     "optional": true
+    }
    }
   },
   "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "next": "^16.2.1",
   "next-auth": "^4.24.13",
   "next-themes": "^0.4.6",
+  "radix-ui": "^1.4.3",
   "react": "19.2.4",
   "react-dom": "19.2.4",
   "shadcn": "^4.1.0",

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,5 +1,7 @@
 import { prisma } from "@/lib/prisma";
 import { HeroSection } from "@/components/section/hero-section";
+import { WorkSection } from "@/components/section/work-section";
+import { ExperienceEditButton } from "@/components/shared/homepage-edit-buttons";
 import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -15,7 +17,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
- const [user, activeCV] = await Promise.all([
+ const [user, activeCV, cvSections] = await Promise.all([
   prisma.user.findFirst({
    orderBy: { createdAt: "asc" },
    select: {
@@ -30,7 +32,12 @@ export default async function HomePage() {
    where: { isActive: true },
    select: { id: true },
   }),
+  prisma.cVSection.findMany({
+   orderBy: [{ type: "asc" }, { order: "asc" }],
+  }),
  ]);
+
+ const experienceItems = cvSections.filter((s) => s.type === "experience");
 
  if (!user) {
   return (
@@ -58,6 +65,18 @@ export default async function HomePage() {
     socialLinks={socialLinks}
     hasActiveCV={!!activeCV}
    />
+
+   {experienceItems.length > 0 && (
+    <section id="work" className="group">
+     <div className="flex min-h-0 flex-col gap-y-4">
+      <div className="flex items-center gap-2">
+       <h2 className="text-xl font-bold">Work Experience</h2>
+       <ExperienceEditButton />
+      </div>
+      <WorkSection items={experienceItems} />
+     </div>
+    </section>
+   )}
   </main>
  );
 }

--- a/src/components/section/work-section.tsx
+++ b/src/components/section/work-section.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { ChevronRight } from "lucide-react";
+import {
+ Accordion,
+ AccordionItem,
+ AccordionTrigger,
+ AccordionContent,
+} from "@/components/ui/accordion";
+
+interface WorkItem {
+ id: string;
+ title: string;
+ subtitle?: string | null;
+ description?: string | null;
+ logoUrl?: string | null;
+ location?: string | null;
+ startDate?: string | null;
+ endDate?: string | null;
+}
+
+interface WorkSectionProps {
+ items: WorkItem[];
+}
+
+function LogoImage({ letter, logoUrl }: { letter: string; logoUrl?: string | null }) {
+ if (logoUrl) {
+  return (
+   <span className="size-8 md:size-10 rounded-full border shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none overflow-hidden block">
+    <Image src={logoUrl} alt="" width={40} height={40} className="size-full object-cover" />
+   </span>
+  );
+ }
+
+ return (
+  <span className="size-8 md:size-10 p-1 border rounded-full shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none flex items-center justify-center text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+   {letter}
+  </span>
+ );
+}
+
+export function WorkSection({ items }: WorkSectionProps) {
+ const [value, setValue] = useState<string | undefined>(items[0]?.id);
+
+ if (items.length === 0) return null;
+
+ return (
+  <Accordion type="single" collapsible value={value} onValueChange={setValue}>
+   {items.map((item) => (
+    <AccordionItem key={item.id} value={item.id} className="border-none">
+     <AccordionTrigger className="group flex w-full items-center gap-3 rounded-lg px-2 py-3 text-left hover:no-underline hover:bg-neutral-50 dark:hover:bg-neutral-900 transition-colors [&>svg:last-child]:hidden">
+      <LogoImage letter={item.title.charAt(0).toUpperCase()} logoUrl={item.logoUrl} />
+
+      <div className="flex-1 min-w-0">
+       <p className="text-sm font-medium leading-tight">{item.subtitle ?? item.title}</p>
+       <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+        {item.subtitle ? item.title : ""}
+        {item.location && item.subtitle ? ` · ${item.location}` : (item.location ?? "")}
+       </p>
+      </div>
+
+      <div className="hidden sm:flex items-center gap-2 text-xs tabular-nums text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">
+       {item.startDate && (
+        <span>
+         {item.startDate} – {item.endDate ?? "Present"}
+        </span>
+       )}
+      </div>
+
+      <ChevronRight className="h-4 w-4 text-neutral-400 shrink-0 opacity-0 -translate-x-1 transition-all duration-200 group-hover:opacity-100 group-hover:translate-x-0 group-data-[state=open]:rotate-90" />
+     </AccordionTrigger>
+
+     {item.description && (
+      <AccordionContent className="ml-11 md:ml-13">
+       <div className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-300 whitespace-pre-line">
+        {item.description}
+       </div>
+      </AccordionContent>
+     )}
+
+     {item.startDate && (
+      <div className="sm:hidden ml-11 md:ml-13 -mt-2 mb-2 text-xs text-neutral-500 dark:text-neutral-400">
+       {item.startDate} – {item.endDate ?? "Present"}
+      </div>
+     )}
+    </AccordionItem>
+   ))}
+  </Accordion>
+ );
+}

--- a/src/components/shared/homepage-edit-buttons.tsx
+++ b/src/components/shared/homepage-edit-buttons.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { EditButton } from "@/components/shared/edit-button";
+import { useDrawerState } from "@/components/shared/drawer-state-provider";
+
+export function HeroEditButton() {
+ const { openDrawer } = useDrawerState();
+ return <EditButton onClick={() => openDrawer("profile")} />;
+}
+
+export function ExperienceEditButton() {
+ const { openDrawer } = useDrawerState();
+ return <EditButton onClick={() => openDrawer("cv-experience")} />;
+}
+
+export function EducationEditButton() {
+ const { openDrawer } = useDrawerState();
+ return <EditButton onClick={() => openDrawer("cv-education")} />;
+}
+
+export function SkillEditButton() {
+ const { openDrawer } = useDrawerState();
+ return <EditButton onClick={() => openDrawer("cv-skill")} />;
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import * as React from "react";
+import { ChevronDownIcon } from "lucide-react";
+import { Accordion as AccordionPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+ return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+ className,
+ ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+ return (
+  <AccordionPrimitive.Item
+   data-slot="accordion-item"
+   className={cn("border-b last:border-b-0", className)}
+   {...props}
+  />
+ );
+}
+
+function AccordionTrigger({
+ className,
+ children,
+ ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+ return (
+  <AccordionPrimitive.Header className="flex">
+   <AccordionPrimitive.Trigger
+    data-slot="accordion-trigger"
+    className={cn(
+     "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+     className
+    )}
+    {...props}
+   >
+    {children}
+    <ChevronDownIcon className="text-neutral-400 pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+   </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+ );
+}
+
+function AccordionContent({
+ className,
+ children,
+ ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+ return (
+  <AccordionPrimitive.Content
+   data-slot="accordion-content"
+   className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+   suppressHydrationWarning
+   {...props}
+  >
+   <div className={cn("pt-0 pb-4", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+ );
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Work Experience section with a timeline layout displaying company, role, dates, and description for each position.

**Changes:**
- Add work experience section with accordion layout

**Impact:**
- `package-lock.json` — Modified (+1716, -1)
- `package.json` — Modified (+1, -0)
- `src/app/(public)/page.tsx` — Modified (+20, -1)
- `src/components/section/work-section.tsx` — Added (+92, -0)
- `src/components/shared/homepage-edit-buttons.tsx` — Added (+24, -0)
- `src/components/ui/accordion.tsx` — Added (+65, -0)

## Linked Issue
**#15** — Build Work Experience section

Closes #15