### PR TITLE
feat(ui): add skills section with categorized tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ next-env.d.ts
 # =============================================================================
 # Auto-generated client — regenerate with `npx prisma generate`
 /src/generated/prisma
+# Local seed data — contains personal info, not committed
+prisma/seed-data.json
 
 # =============================================================================
 # Linting & Formatting cache

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -37,8 +37,10 @@ async function main() {
   ...data.education.map((e: Record<string, unknown>) => ({ ...e, type: "education" })),
  ];
 
- await prisma.cVSection.deleteMany();
- await prisma.cVSection.createMany({ data: sections });
+ await prisma.$transaction([
+  prisma.cVSection.deleteMany(),
+  prisma.cVSection.createMany({ data: sections }),
+ ]);
  console.log(
   "Seeded:",
   data.experiences.length,
@@ -54,6 +56,12 @@ async function main() {
  if (!existing) {
   await prisma.siteSettings.create({ data: data.siteSettings });
   console.log("Site settings created.");
+ } else {
+  await prisma.siteSettings.update({
+   where: { id: existing.id },
+   data: data.siteSettings,
+  });
+  console.log("Site settings updated.");
  }
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,65 @@
+import { PrismaClient } from "../src/generated/prisma";
+import { PrismaNeon } from "@prisma/adapter-neon";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { config } from "dotenv";
+
+// Load .env before using process.env
+config({ path: resolve(__dirname, "../.env") });
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+ throw new Error("DATABASE_URL is not set. Check your .env file.");
+}
+
+const adapter = new PrismaNeon({ connectionString: databaseUrl });
+const prisma = new PrismaClient({ adapter });
+
+// Load seed data from local JSON (gitignored)
+const dataPath = resolve(__dirname, "seed-data.json");
+const data = JSON.parse(readFileSync(dataPath, "utf-8"));
+
+async function main() {
+ console.log("Connecting to database...");
+
+ // ── User ──
+ const user = await prisma.user.upsert({
+  where: { email: data.user.email },
+  update: {},
+  create: data.user,
+ });
+ console.log("User:", user.name);
+
+ // ── CV Sections ──
+ const sections = [
+  ...data.experiences.map((e: Record<string, unknown>) => ({ ...e, type: "experience" })),
+  ...data.skills.map((s: Record<string, unknown>) => ({ ...s, type: "skill" })),
+  ...data.education.map((e: Record<string, unknown>) => ({ ...e, type: "education" })),
+ ];
+
+ await prisma.cVSection.deleteMany();
+ await prisma.cVSection.createMany({ data: sections });
+ console.log(
+  "Seeded:",
+  data.experiences.length,
+  "experiences,",
+  data.skills.length,
+  "skills,",
+  data.education.length,
+  "education"
+ );
+
+ // ── Site Settings ──
+ const existing = await prisma.siteSettings.findFirst();
+ if (!existing) {
+  await prisma.siteSettings.create({ data: data.siteSettings });
+  console.log("Site settings created.");
+ }
+}
+
+main()
+ .catch((e) => {
+  console.error(e);
+  process.exit(1);
+ })
+ .finally(() => prisma.$disconnect());

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,7 +1,8 @@
 import { prisma } from "@/lib/prisma";
 import { HeroSection } from "@/components/section/hero-section";
 import { WorkSection } from "@/components/section/work-section";
-import { ExperienceEditButton } from "@/components/shared/homepage-edit-buttons";
+import { SkillsSection } from "@/components/section/skills-section";
+import { ExperienceEditButton, SkillEditButton } from "@/components/shared/homepage-edit-buttons";
 import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -38,6 +39,7 @@ export default async function HomePage() {
  ]);
 
  const experienceItems = cvSections.filter((s) => s.type === "experience");
+ const skillItems = cvSections.filter((s) => s.type === "skill");
 
  if (!user) {
   return (
@@ -74,6 +76,18 @@ export default async function HomePage() {
        <ExperienceEditButton />
       </div>
       <WorkSection items={experienceItems} />
+     </div>
+    </section>
+   )}
+
+   {skillItems.length > 0 && (
+    <section id="skills" className="group">
+     <div className="flex min-h-0 flex-col gap-y-4">
+      <div className="flex items-center gap-2">
+       <h2 className="text-xl font-bold">Skills</h2>
+       <SkillEditButton />
+      </div>
+      <SkillsSection items={skillItems} />
      </div>
     </section>
    )}

--- a/src/components/layout/dock-nav.tsx
+++ b/src/components/layout/dock-nav.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { useTheme } from "next-themes";
 import {
@@ -40,6 +41,11 @@ interface DockNavProps {
 
 export function DockNav({ socialLinks, hasActiveCV, isAdmin, pageVisibility }: DockNavProps) {
  const { resolvedTheme, setTheme } = useTheme();
+ const mounted = useSyncExternalStore(
+  () => () => {},
+  () => true,
+  () => false
+ );
 
  const allNavItems: NavItem[] = [
   { href: "/", label: "Home", icon: Home },
@@ -128,19 +134,21 @@ export function DockNav({ socialLinks, hasActiveCV, isAdmin, pageVisibility }: D
       orientation="vertical"
       className="h-2/3 m-auto w-px bg-neutral-200 dark:bg-neutral-800"
      />
-     <Tooltip>
-      <TooltipTrigger
-       onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-       aria-label="Toggle theme"
-      >
-       <DockIcon className={DOCK_ICON_CLASS}>
-        {resolvedTheme === "dark" ? <Sun className="size-full" /> : <Moon className="size-full" />}
-       </DockIcon>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={8} className={DOCK_TOOLTIP_CLASS}>
-       <p>Theme</p>
-      </TooltipContent>
-     </Tooltip>
+     {mounted && (
+      <Tooltip>
+       <TooltipTrigger
+        onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+        aria-label="Toggle theme"
+       >
+        <DockIcon className={DOCK_ICON_CLASS}>
+         {resolvedTheme === "dark" ? <Sun className="size-full" /> : <Moon className="size-full" />}
+        </DockIcon>
+       </TooltipTrigger>
+       <TooltipContent side="bottom" sideOffset={8} className={DOCK_TOOLTIP_CLASS}>
+        <p>Theme</p>
+       </TooltipContent>
+      </Tooltip>
+     )}
 
      {isAdmin && <AdminDockItems />}
     </Dock>

--- a/src/components/section/skills-section.tsx
+++ b/src/components/section/skills-section.tsx
@@ -1,0 +1,44 @@
+import { Badge } from "@/components/ui/badge";
+
+interface SkillItem {
+ id: string;
+ title: string;
+ subtitle?: string | null;
+}
+
+interface SkillsSectionProps {
+ items: SkillItem[];
+}
+
+export function SkillsSection({ items }: SkillsSectionProps) {
+ if (items.length === 0) return null;
+
+ // Group skills by category (subtitle), defaulting to "Other"
+ const grouped = items.reduce<Record<string, SkillItem[]>>((acc, item) => {
+  const category = item.subtitle ?? "Other";
+  if (!acc[category]) acc[category] = [];
+  acc[category].push(item);
+  return acc;
+ }, {});
+
+ return (
+  <div className="flex flex-col gap-6">
+   {Object.entries(grouped).map(([category, skills]) => (
+    <div key={category}>
+     <h3 className="text-sm font-medium text-neutral-500 dark:text-neutral-400 mb-2">{category}</h3>
+     <div className="flex flex-wrap gap-2">
+      {skills.map((skill) => (
+       <Badge
+        key={skill.id}
+        variant="secondary"
+        className="bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 border-neutral-200 dark:border-neutral-700 hover:bg-neutral-200 dark:hover:bg-neutral-700"
+       >
+        {skill.title}
+       </Badge>
+      ))}
+     </div>
+    </div>
+   ))}
+  </div>
+ );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+ "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+ {
+  variants: {
+   variant: {
+    default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+    secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+    destructive:
+     "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+    outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+    ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+    link: "text-primary underline-offset-4 hover:underline",
+   },
+  },
+  defaultVariants: {
+   variant: "default",
+  },
+ }
+);
+
+function Badge({
+ className,
+ variant = "default",
+ render,
+ ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+ return useRender({
+  defaultTagName: "span",
+  props: mergeProps<"span">(
+   {
+    className: cn(badgeVariants({ variant }), className),
+   },
+   props
+  ),
+  render,
+  state: {
+   slot: "badge",
+   variant,
+  },
+ });
+}
+
+export { Badge, badgeVariants };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,34 @@
 {
-  "compilerOptions": {
-    "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "react-jsx",
-    "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "**/*.mts"
+ "compilerOptions": {
+  "target": "ES2017",
+  "lib": ["dom", "dom.iterable", "esnext"],
+  "allowJs": true,
+  "skipLibCheck": true,
+  "strict": true,
+  "noEmit": true,
+  "esModuleInterop": true,
+  "module": "esnext",
+  "moduleResolution": "bundler",
+  "resolveJsonModule": true,
+  "isolatedModules": true,
+  "jsx": "react-jsx",
+  "incremental": true,
+  "plugins": [
+   {
+    "name": "next"
+   }
   ],
-  "exclude": ["node_modules"]
+  "paths": {
+   "@/*": ["./src/*"]
+  }
+ },
+ "include": [
+  "next-env.d.ts",
+  "**/*.ts",
+  "**/*.tsx",
+  ".next/types/**/*.ts",
+  ".next/dev/types/**/*.ts",
+  "**/*.mts"
+ ],
+ "exclude": ["node_modules", "prisma/seed.ts"]
 }


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Skills section displaying skills organized by category, such as technical skills and tools.

**Changes:**
- Add skills section with categorized tags
- Address review feedback on skills section and seed script

**Impact:**
- `.gitignore` — Modified (+2, -0)
- `prisma/seed.ts` — Added (+73, -0)
- `src/app/(public)/page.tsx` — Modified (+15, -1)
- `src/components/layout/dock-nav.tsx` — Modified (+21, -13)
- `src/components/section/skills-section.tsx` — Added (+44, -0)
- `src/components/ui/badge.tsx` — Added (+51, -0)
- `tsconfig.json` — Modified (+31, -31)

## Linked Issue
**#16** — Build Skills section

Closes #16