### PR TITLE
feat(ui): add education section with institution and dates

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -2,7 +2,12 @@ import { prisma } from "@/lib/prisma";
 import { HeroSection } from "@/components/section/hero-section";
 import { WorkSection } from "@/components/section/work-section";
 import { SkillsSection } from "@/components/section/skills-section";
-import { ExperienceEditButton, SkillEditButton } from "@/components/shared/homepage-edit-buttons";
+import { EducationSection } from "@/components/section/education-section";
+import {
+ ExperienceEditButton,
+ SkillEditButton,
+ EducationEditButton,
+} from "@/components/shared/homepage-edit-buttons";
 import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
@@ -40,6 +45,7 @@ export default async function HomePage() {
 
  const experienceItems = cvSections.filter((s) => s.type === "experience");
  const skillItems = cvSections.filter((s) => s.type === "skill");
+ const educationItems = cvSections.filter((s) => s.type === "education");
 
  if (!user) {
   return (
@@ -88,6 +94,18 @@ export default async function HomePage() {
        <SkillEditButton />
       </div>
       <SkillsSection items={skillItems} />
+     </div>
+    </section>
+   )}
+
+   {educationItems.length > 0 && (
+    <section id="education" className="group">
+     <div className="flex min-h-0 flex-col gap-y-4">
+      <div className="flex items-center gap-2">
+       <h2 className="text-xl font-bold">Education</h2>
+       <EducationEditButton />
+      </div>
+      <EducationSection items={educationItems} />
      </div>
     </section>
    )}

--- a/src/components/section/education-section.tsx
+++ b/src/components/section/education-section.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import { LogoImage } from "@/components/shared/logo-image";
 
 interface EducationItem {
  id: string;
@@ -11,22 +11,6 @@ interface EducationItem {
 
 interface EducationSectionProps {
  items: EducationItem[];
-}
-
-function LogoImage({ letter, logoUrl }: { letter: string; logoUrl?: string | null }) {
- if (logoUrl) {
-  return (
-   <span className="size-8 md:size-10 rounded-full border shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none overflow-hidden block">
-    <Image src={logoUrl} alt="" width={40} height={40} className="size-full object-cover" />
-   </span>
-  );
- }
-
- return (
-  <span className="size-8 md:size-10 p-1 border rounded-full shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none flex items-center justify-center text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-   {letter}
-  </span>
- );
 }
 
 export function EducationSection({ items }: EducationSectionProps) {

--- a/src/components/section/education-section.tsx
+++ b/src/components/section/education-section.tsx
@@ -1,0 +1,57 @@
+import Image from "next/image";
+
+interface EducationItem {
+ id: string;
+ title: string;
+ subtitle?: string | null;
+ logoUrl?: string | null;
+ startDate?: string | null;
+ endDate?: string | null;
+}
+
+interface EducationSectionProps {
+ items: EducationItem[];
+}
+
+function LogoImage({ letter, logoUrl }: { letter: string; logoUrl?: string | null }) {
+ if (logoUrl) {
+  return (
+   <span className="size-8 md:size-10 rounded-full border shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none overflow-hidden block">
+    <Image src={logoUrl} alt="" width={40} height={40} className="size-full object-cover" />
+   </span>
+  );
+ }
+
+ return (
+  <span className="size-8 md:size-10 p-1 border rounded-full shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none flex items-center justify-center text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+   {letter}
+  </span>
+ );
+}
+
+export function EducationSection({ items }: EducationSectionProps) {
+ if (items.length === 0) return null;
+
+ return (
+  <div className="flex flex-col gap-2">
+   {items.map((item) => (
+    <div key={item.id} className="flex items-center gap-3 rounded-lg px-2 py-3">
+     <LogoImage letter={item.title.charAt(0).toUpperCase()} logoUrl={item.logoUrl} />
+
+     <div className="flex-1 min-w-0">
+      <p className="text-sm font-medium leading-tight">{item.title}</p>
+      {item.subtitle && (
+       <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">{item.subtitle}</p>
+      )}
+     </div>
+
+     {item.startDate && (
+      <div className="text-xs tabular-nums text-neutral-500 dark:text-neutral-400 whitespace-nowrap shrink-0">
+       {item.startDate} – {item.endDate ?? "Present"}
+      </div>
+     )}
+    </div>
+   ))}
+  </div>
+ );
+}

--- a/src/components/section/work-section.tsx
+++ b/src/components/section/work-section.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import Image from "next/image";
 import { ChevronRight } from "lucide-react";
+import { LogoImage } from "@/components/shared/logo-image";
 import {
  Accordion,
  AccordionItem,
@@ -23,22 +23,6 @@ interface WorkItem {
 
 interface WorkSectionProps {
  items: WorkItem[];
-}
-
-function LogoImage({ letter, logoUrl }: { letter: string; logoUrl?: string | null }) {
- if (logoUrl) {
-  return (
-   <span className="size-8 md:size-10 rounded-full border shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none overflow-hidden block">
-    <Image src={logoUrl} alt="" width={40} height={40} className="size-full object-cover" />
-   </span>
-  );
- }
-
- return (
-  <span className="size-8 md:size-10 p-1 border rounded-full shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none flex items-center justify-center text-xs font-semibold text-neutral-500 dark:text-neutral-400">
-   {letter}
-  </span>
- );
 }
 
 export function WorkSection({ items }: WorkSectionProps) {

--- a/src/components/shared/logo-image.tsx
+++ b/src/components/shared/logo-image.tsx
@@ -1,0 +1,22 @@
+import Image from "next/image";
+
+interface LogoImageProps {
+ letter: string;
+ logoUrl?: string | null;
+}
+
+export function LogoImage({ letter, logoUrl }: LogoImageProps) {
+ if (logoUrl) {
+  return (
+   <span className="size-8 md:size-10 rounded-full border shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none overflow-hidden block">
+    <Image src={logoUrl} alt="" width={40} height={40} className="size-full object-cover" />
+   </span>
+  );
+ }
+
+ return (
+  <span className="size-8 md:size-10 p-1 border rounded-full shadow ring-2 ring-neutral-200 dark:ring-neutral-700 bg-neutral-100 dark:bg-neutral-800 flex-none flex items-center justify-center text-xs font-semibold text-neutral-500 dark:text-neutral-400">
+   {letter}
+  </span>
+ );
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Education section displaying academic background with institution, degree, and dates.

**Changes:**
- Add education section with institution and dates
- Extract shared LogoImage component and add education section

**Impact:**
- `src/app/(public)/page.tsx` — Modified (+19, -1)
- `src/components/section/education-section.tsx` — Added (+41, -0)
- `src/components/section/work-section.tsx` — Modified (+1, -17)
- `src/components/shared/logo-image.tsx` — Added (+22, -0)

## Linked Issue
**#19** — Build Education section

Closes #19