### PR TITLE
feat(ui): add projects section with card grid and tech stack badges

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -51,6 +51,15 @@ async function main() {
   "education"
  );
 
+ // ── Projects ──
+ if (data.projects && data.projects.length > 0) {
+  await prisma.$transaction([
+   prisma.project.deleteMany(),
+   prisma.project.createMany({ data: data.projects }),
+  ]);
+  console.log("Seeded:", data.projects.length, "projects");
+ }
+
  // ── Site Settings ──
  const existing = await prisma.siteSettings.findFirst();
  if (!existing) {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -52,12 +52,17 @@ async function main() {
  );
 
  // ── Projects ──
- if (data.projects && data.projects.length > 0) {
-  await prisma.$transaction([
-   prisma.project.deleteMany(),
-   prisma.project.createMany({ data: data.projects }),
-  ]);
-  console.log("Seeded:", data.projects.length, "projects");
+ if (data.projects) {
+  if (data.projects.length > 0) {
+   await prisma.$transaction([
+    prisma.project.deleteMany(),
+    prisma.project.createMany({ data: data.projects }),
+   ]);
+   console.log("Seeded:", data.projects.length, "projects");
+  } else {
+   await prisma.project.deleteMany();
+   console.log("Seeded: 0 projects (existing projects cleared)");
+  }
  }
 
  // ── Site Settings ──

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -45,6 +45,7 @@ export default async function HomePage() {
   }),
   prisma.project.findMany({
    orderBy: [{ featured: "desc" }, { order: "asc" }],
+   take: 5,
   }),
  ]);
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -3,6 +3,8 @@ import { HeroSection } from "@/components/section/hero-section";
 import { WorkSection } from "@/components/section/work-section";
 import { SkillsSection } from "@/components/section/skills-section";
 import { EducationSection } from "@/components/section/education-section";
+import { ProjectsSection } from "@/components/section/projects-section";
+import Link from "next/link";
 import {
  ExperienceEditButton,
  SkillEditButton,
@@ -23,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
- const [user, activeCV, cvSections] = await Promise.all([
+ const [user, activeCV, cvSections, projects] = await Promise.all([
   prisma.user.findFirst({
    orderBy: { createdAt: "asc" },
    select: {
@@ -40,6 +42,9 @@ export default async function HomePage() {
   }),
   prisma.cVSection.findMany({
    orderBy: [{ type: "asc" }, { order: "asc" }],
+  }),
+  prisma.project.findMany({
+   orderBy: [{ featured: "desc" }, { order: "asc" }],
   }),
  ]);
 
@@ -106,6 +111,25 @@ export default async function HomePage() {
        <EducationEditButton />
       </div>
       <EducationSection items={educationItems} />
+     </div>
+    </section>
+   )}
+
+   {projects.length > 0 && (
+    <section id="projects" className="group">
+     <div className="flex min-h-0 flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+       <h2 className="text-xl font-bold">Projects</h2>
+       {projects.length > 4 && (
+        <Link
+         href="/projects"
+         className="text-xs text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+        >
+         View all →
+        </Link>
+       )}
+      </div>
+      <ProjectsSection items={projects} />
      </div>
     </section>
    )}

--- a/src/components/section/projects-section.tsx
+++ b/src/components/section/projects-section.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { ExternalLink, GithubIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { isSafeUrl } from "@/lib/utils";
 
 interface ProjectItem {
  id: string;
@@ -45,9 +46,9 @@ function ProjectCard({ project }: { project: ProjectItem }) {
 
    {project.techStack.length > 0 && (
     <div className="flex flex-wrap gap-1">
-     {project.techStack.map((tech) => (
+     {project.techStack.map((tech, index) => (
       <Badge
-       key={tech}
+       key={`${tech}-${index}`}
        variant="secondary"
        className="text-[10px] px-1.5 py-0 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border-neutral-200 dark:border-neutral-700"
       >
@@ -58,7 +59,7 @@ function ProjectCard({ project }: { project: ProjectItem }) {
    )}
 
    <div className="flex items-center gap-3">
-    {project.liveUrl && (
+    {project.liveUrl && isSafeUrl(project.liveUrl) && (
      <Link
       href={project.liveUrl}
       target="_blank"
@@ -69,7 +70,7 @@ function ProjectCard({ project }: { project: ProjectItem }) {
       Live
      </Link>
     )}
-    {project.repoUrl && (
+    {project.repoUrl && isSafeUrl(project.repoUrl) && (
      <Link
       href={project.repoUrl}
       target="_blank"

--- a/src/components/section/projects-section.tsx
+++ b/src/components/section/projects-section.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import Image from "next/image";
+import { ExternalLink, GithubIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+interface ProjectItem {
+ id: string;
+ title: string;
+ slug: string;
+ description?: string | null;
+ techStack: string[];
+ liveUrl?: string | null;
+ repoUrl?: string | null;
+ imageUrl?: string | null;
+}
+
+interface ProjectsSectionProps {
+ items: ProjectItem[];
+ showAll?: boolean;
+}
+
+function ProjectCard({ project }: { project: ProjectItem }) {
+ return (
+  <div className="group relative flex flex-col gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900">
+   {project.imageUrl && (
+    <div className="overflow-hidden rounded-md">
+     <Image
+      src={project.imageUrl}
+      alt={project.title}
+      width={600}
+      height={340}
+      className="w-full object-cover aspect-video"
+     />
+    </div>
+   )}
+
+   <div className="flex-1 space-y-2">
+    <h3 className="text-sm font-semibold leading-tight">{project.title}</h3>
+    {project.description && (
+     <p className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2">
+      {project.description}
+     </p>
+    )}
+   </div>
+
+   {project.techStack.length > 0 && (
+    <div className="flex flex-wrap gap-1">
+     {project.techStack.map((tech) => (
+      <Badge
+       key={tech}
+       variant="secondary"
+       className="text-[10px] px-1.5 py-0 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border-neutral-200 dark:border-neutral-700"
+      >
+       {tech}
+      </Badge>
+     ))}
+    </div>
+   )}
+
+   <div className="flex items-center gap-3">
+    {project.liveUrl && (
+     <Link
+      href={project.liveUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+     >
+      <ExternalLink className="h-3 w-3" />
+      Live
+     </Link>
+    )}
+    {project.repoUrl && (
+     <Link
+      href={project.repoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-xs text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+     >
+      <GithubIcon className="h-3 w-3" />
+      Repo
+     </Link>
+    )}
+   </div>
+  </div>
+ );
+}
+
+export function ProjectsSection({ items, showAll = false }: ProjectsSectionProps) {
+ if (items.length === 0) return null;
+
+ const displayed = showAll ? items : items.slice(0, 4);
+
+ return (
+  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+   {displayed.map((project) => (
+    <ProjectCard key={project.id} project={project} />
+   ))}
+  </div>
+ );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,5 +6,18 @@ import { twMerge } from "tailwind-merge";
  * Combines clsx (conditional classes) with tailwind-merge (deduplication).
  */
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+ return twMerge(clsx(inputs));
+}
+
+/**
+ * Validates that a URL uses http or https protocol.
+ * Prevents XSS/open-redirect from javascript: or other unsafe protocols.
+ */
+export function isSafeUrl(url: string): boolean {
+ try {
+  const parsed = new URL(url);
+  return parsed.protocol === "http:" || parsed.protocol === "https:";
+ } catch {
+  return false;
+ }
 }


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Projects section displaying a card grid of portfolio projects with tech stack badges and links to live demos and repositories.

**Changes:**
- Add projects section with card grid and tech stack badges
- Address review feedback on projects section and seed script

**Impact:**
- `prisma/seed.ts` — Modified (+14, -0)
- `src/app/(public)/page.tsx` — Modified (+26, -1)
- `src/components/section/projects-section.tsx` — Added (+101, -0)
- `src/lib/utils.ts` — Modified (+14, -1)

## Linked Issue
**#17** — Build Projects section

Closes #17