### PR TITLE
feat(ui): add blog section, listing page, and post detail page

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -1,0 +1,114 @@
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+interface BlogPostPageProps {
+ params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
+ const { slug } = await params;
+ const post = await prisma.blogPost.findUnique({
+  where: { slug },
+  select: { title: true, excerpt: true },
+ });
+
+ if (!post) return { title: "Post not found" };
+
+ return {
+  title: post.title,
+  description: post.excerpt ?? undefined,
+ };
+}
+
+function formatDate(date: Date): string {
+ return new Intl.DateTimeFormat("en-US", {
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+ }).format(date);
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+ const { slug } = await params;
+
+ const post = await prisma.blogPost.findUnique({
+  where: { slug },
+  select: {
+   id: true,
+   title: true,
+   slug: true,
+   content: true,
+   contentHtml: true,
+   excerpt: true,
+   category: true,
+   tags: true,
+   publishedAt: true,
+   readTimeMin: true,
+  },
+ });
+
+ if (!post || post.publishedAt === null) return notFound();
+
+ return (
+  <main className="min-h-dvh flex flex-col gap-8 max-w-2xl mx-auto px-6 w-full py-16 md:py-24">
+   <div className="flex items-center gap-3">
+    <Link
+     href="/blog"
+     className="inline-flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+    >
+     <ArrowLeft className="h-4 w-4" />
+     Back to blog
+    </Link>
+   </div>
+
+   <article className="flex flex-col gap-6">
+    <header className="flex flex-col gap-3">
+     <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+      {post.publishedAt && <time>{formatDate(post.publishedAt)}</time>}
+      {post.readTimeMin && <span>· {post.readTimeMin} min read</span>}
+     </div>
+
+     <h1 className="text-2xl font-bold tracking-tight">{post.title}</h1>
+
+     {post.excerpt && (
+      <p className="text-sm text-neutral-500 dark:text-neutral-400">{post.excerpt}</p>
+     )}
+
+     <div className="flex flex-wrap gap-2">
+      {post.category && (
+       <Badge
+        variant="secondary"
+        className="bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border-neutral-200 dark:border-neutral-700"
+       >
+        {post.category}
+       </Badge>
+      )}
+      {post.tags.map((tag, index) => (
+       <Badge
+        key={`${tag}-${index}`}
+        variant="secondary"
+        className="bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border-neutral-200 dark:border-neutral-700"
+       >
+        {tag}
+       </Badge>
+      ))}
+     </div>
+    </header>
+
+    <div className="text-sm leading-relaxed text-neutral-700 dark:text-neutral-300 whitespace-pre-line">
+     {post.contentHtml ? (
+      <div dangerouslySetInnerHTML={{ __html: post.contentHtml }} />
+     ) : (
+      post.content
+     )}
+    </div>
+   </article>
+  </main>
+ );
+}

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -1,0 +1,60 @@
+import { prisma } from "@/lib/prisma";
+import { BlogSection } from "@/components/section/blog-section";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(): Promise<Metadata> {
+ const settings = await prisma.siteSettings.findFirst({
+  select: { siteTitle: true },
+ });
+ return {
+  title: `Blog — ${settings?.siteTitle ?? "Portfolio"}`,
+  description: "Articles and technical writing",
+ };
+}
+
+export default async function BlogPage() {
+ const posts = await prisma.blogPost.findMany({
+  where: { status: "published" },
+  orderBy: { publishedAt: "desc" },
+  select: {
+   id: true,
+   title: true,
+   slug: true,
+   excerpt: true,
+   category: true,
+   publishedAt: true,
+   readTimeMin: true,
+  },
+ });
+
+ return (
+  <main className="min-h-dvh flex flex-col gap-8 max-w-2xl mx-auto px-6 w-full py-16 md:py-24">
+   <div className="flex items-center gap-3">
+    <Link
+     href="/"
+     className="inline-flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+    >
+     <ArrowLeft className="h-4 w-4" />
+     Back
+    </Link>
+   </div>
+
+   <div>
+    <h1 className="text-2xl font-bold tracking-tight">Blog</h1>
+    <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">
+     Articles and technical writing.
+    </p>
+   </div>
+
+   {posts.length > 0 ? (
+    <BlogSection posts={posts} />
+   ) : (
+    <p className="text-neutral-500 dark:text-neutral-400">No posts yet.</p>
+   )}
+  </main>
+ );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -4,6 +4,7 @@ import { WorkSection } from "@/components/section/work-section";
 import { SkillsSection } from "@/components/section/skills-section";
 import { EducationSection } from "@/components/section/education-section";
 import { ProjectsSection } from "@/components/section/projects-section";
+import { BlogSection } from "@/components/section/blog-section";
 import Link from "next/link";
 import {
  ExperienceEditButton,
@@ -25,7 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function HomePage() {
- const [user, activeCV, cvSections, projects] = await Promise.all([
+ const [user, activeCV, cvSections, projects, recentPosts] = await Promise.all([
   prisma.user.findFirst({
    orderBy: { createdAt: "asc" },
    select: {
@@ -46,6 +47,20 @@ export default async function HomePage() {
   prisma.project.findMany({
    orderBy: [{ featured: "desc" }, { order: "asc" }],
    take: 5,
+  }),
+  prisma.blogPost.findMany({
+   where: { status: "published" },
+   orderBy: { publishedAt: "desc" },
+   take: 4,
+   select: {
+    id: true,
+    title: true,
+    slug: true,
+    excerpt: true,
+    category: true,
+    publishedAt: true,
+    readTimeMin: true,
+   },
   }),
  ]);
 
@@ -131,6 +146,23 @@ export default async function HomePage() {
        )}
       </div>
       <ProjectsSection items={projects} />
+     </div>
+    </section>
+   )}
+
+   {recentPosts.length > 0 && (
+    <section id="blog" className="group">
+     <div className="flex min-h-0 flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+       <h2 className="text-xl font-bold">Blog</h2>
+       <Link
+        href="/blog"
+        className="text-xs text-neutral-500 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+       >
+        View all →
+       </Link>
+      </div>
+      <BlogSection posts={recentPosts} />
      </div>
     </section>
    )}

--- a/src/components/section/blog-section.tsx
+++ b/src/components/section/blog-section.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+
+interface BlogPostItem {
+ id: string;
+ title: string;
+ slug: string;
+ excerpt?: string | null;
+ category?: string | null;
+ publishedAt?: Date | null;
+ readTimeMin?: number | null;
+}
+
+interface BlogSectionProps {
+ posts: BlogPostItem[];
+}
+
+function formatDate(date: Date): string {
+ return new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+ }).format(date);
+}
+
+function BlogPostCard({ post }: { post: BlogPostItem }) {
+ return (
+  <Link
+   href={`/blog/${post.slug}`}
+   className="group flex flex-col gap-2 rounded-lg border border-neutral-200 dark:border-neutral-800 p-4 transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900"
+  >
+   <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400">
+    {post.publishedAt && <time>{formatDate(post.publishedAt)}</time>}
+    {post.readTimeMin && <span>· {post.readTimeMin} min read</span>}
+   </div>
+
+   <h3 className="text-sm font-semibold leading-tight group-hover:text-neutral-600 dark:group-hover:text-neutral-300 transition-colors">
+    {post.title}
+   </h3>
+
+   {post.excerpt && (
+    <p className="text-xs text-neutral-500 dark:text-neutral-400 line-clamp-2">{post.excerpt}</p>
+   )}
+
+   {post.category && (
+    <Badge
+     variant="secondary"
+     className="w-fit text-[10px] px-1.5 py-0 bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border-neutral-200 dark:border-neutral-700"
+    >
+     {post.category}
+    </Badge>
+   )}
+  </Link>
+ );
+}
+
+export function BlogSection({ posts }: BlogSectionProps) {
+ if (posts.length === 0) return null;
+
+ return (
+  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+   {posts.map((post) => (
+    <BlogPostCard key={post.id} post={post} />
+   ))}
+  </div>
+ );
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build the Technical Blog section on the homepage as a preview, and a dedicated `/blog` page with list and detail views. Blog posts use rich text, are CMS-driven, and use slug-based routing.

**Changes:**
- Add blog section, listing page, and post detail page

**Impact:**
- `src/app/(public)/blog/[slug]/page.tsx` — Added (+114, -0)
- `src/app/(public)/blog/page.tsx` — Added (+60, -0)
- `src/app/(public)/page.tsx` — Modified (+33, -1)
- `src/components/section/blog-section.tsx` — Added (+67, -0)

## Linked Issue
**#20** — Build Technical Blog section and dedicated blog page

Closes #20