### PR TITLE
feat(ui): add site settings drawer with metadata, accent color, and page visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"
@@ -11888,6 +11889,15 @@
    },
    "funding": {
     "url": "https://github.com/sponsors/sindresorhus"
+   }
+  },
+  "node_modules/sonner": {
+   "version": "2.0.7",
+   "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+   "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+   "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+    "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
    }
   },
   "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "react": "19.2.4",
   "react-dom": "19.2.4",
   "shadcn": "^4.1.0",
+  "sonner": "^2.0.7",
   "tailwind-merge": "^3.5.0",
   "tw-animate-css": "^1.4.0",
   "zod": "^4.3.6"

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -5,7 +5,9 @@ import { DrawerStateProvider } from "@/components/shared/drawer-state-provider";
 import { FlickeringGrid } from "@/components/shared/flickering-grid";
 import { MaintenanceScreen } from "@/components/shared/maintenance-screen";
 import { DockNav } from "@/components/layout/dock-nav";
+import { GlobalDrawers } from "@/components/shared/global-drawers";
 import { prisma } from "@/lib/prisma";
+import { Toaster } from "sonner";
 
 export const dynamic = "force-dynamic";
 
@@ -67,6 +69,10 @@ export default async function PublicLayout({ children }: { children: React.React
 
      {/* Page content — offset for dock */}
      <div className="relative z-10 pt-20">{children}</div>
+
+     {/* Admin drawers */}
+     <GlobalDrawers />
+     <Toaster position="bottom-right" />
     </div>
    </DrawerStateProvider>
   </AuthProvider>

--- a/src/components/shared/global-drawers.tsx
+++ b/src/components/shared/global-drawers.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useDrawerState } from "./drawer-state-provider";
+import { SettingsDrawer } from "./settings-drawer";
+
+export function GlobalDrawers() {
+ const { open, closeDrawer } = useDrawerState();
+
+ return (
+  <>
+   <SettingsDrawer open={open === "settings"} onClose={closeDrawer} />
+   {/* Future drawers: profile, cv-experience, cv-education, cv-skill, cv-documents, users */}
+  </>
+ );
+}

--- a/src/components/shared/settings-drawer.tsx
+++ b/src/components/shared/settings-drawer.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import { Newspaper, FolderOpen, FileText, Users, ChevronRight } from "lucide-react";
+import { UnsavedChangesDialog } from "./unsaved-changes-dialog";
+import { useConfirmClose } from "@/hooks/use-confirm-close";
+import { useDrawerState, type GlobalDrawer } from "./drawer-state-provider";
+import { apiFetch } from "@/lib/api-client";
+
+interface SiteSettingsData {
+ siteTitle?: string;
+ siteDescription?: string;
+ accentColor?: string;
+ faviconUrl?: string;
+ footerText?: string;
+ maintenanceMode?: boolean;
+ showBlog?: boolean;
+ showProjects?: boolean;
+}
+
+const publicPages: {
+ key: "showBlog" | "showProjects";
+ label: string;
+ description: string;
+ icon: React.ComponentType<{ className?: string }>;
+}[] = [
+ { key: "showBlog", label: "Blog", description: "Articles and technical writing", icon: Newspaper },
+ {
+  key: "showProjects",
+  label: "Projects",
+  description: "Portfolio project showcase",
+  icon: FolderOpen,
+ },
+];
+
+const managementItems: {
+ label: string;
+ description: string;
+ icon: React.ComponentType<{ className?: string }>;
+ drawer: GlobalDrawer;
+}[] = [
+ {
+  label: "Resume",
+  description: "Upload and manage your CV",
+  icon: FileText,
+  drawer: "cv-documents",
+ },
+ {
+  label: "Users",
+  description: "Manage admin access",
+  icon: Users,
+  drawer: "users",
+ },
+];
+
+interface SettingsDrawerProps {
+ open: boolean;
+ onClose: () => void;
+}
+
+export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
+ const router = useRouter();
+ const { openDrawer } = useDrawerState();
+ const { markDirty, resetDirty, confirmClose, showConfirm, cancelClose, forceClose } =
+  useConfirmClose(onClose);
+ const [settings, setSettings] = useState<SiteSettingsData>({});
+ const [saving, setSaving] = useState(false);
+ const [loaded, setLoaded] = useState(false);
+ const [loadError, setLoadError] = useState(false);
+
+ useEffect(() => {
+  if (open && !loaded) {
+   setLoadError(false);
+   fetch("/api/settings")
+    .then((r) => {
+     if (!r.ok) throw new Error();
+     return r.json();
+    })
+    .then((s) => {
+     setSettings(s ?? {});
+     setLoaded(true);
+    })
+    .catch(() => {
+     setLoadError(true);
+     toast.error("Failed to load settings.");
+    });
+  }
+  if (!open) {
+   setLoaded(false);
+   setLoadError(false);
+  }
+ }, [open, loaded]);
+
+ function set(key: string, value: unknown) {
+  markDirty();
+  setSettings((prev) => ({ ...prev, [key]: value }));
+ }
+
+ async function handleSave() {
+  setSaving(true);
+  try {
+   await apiFetch("/api/settings", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+   });
+   toast.success("Settings saved!");
+   resetDirty();
+   router.refresh();
+   onClose();
+  } catch (err) {
+   toast.error(err instanceof Error ? err.message : "Save failed.");
+  } finally {
+   setSaving(false);
+  }
+ }
+
+ const accentColor = settings.accentColor ?? "#D4A853";
+
+ return (
+  <Sheet open={open} onOpenChange={(v) => !v && confirmClose()}>
+   <SheetContent className="w-full sm:max-w-lg! p-0 flex flex-col overflow-visible">
+    <SheetHeader className="px-6 pt-6 pb-4">
+     <SheetTitle>Site Settings</SheetTitle>
+    </SheetHeader>
+
+    <ScrollArea className="flex-1 min-h-0 px-6">
+     {loadError && (
+      <p className="text-sm text-red-500 py-4">
+       Failed to load settings. Please close and try again.
+      </p>
+     )}
+     <div className="space-y-6 pb-6">
+      {/* Site info */}
+      <div className="space-y-4">
+       <div className="space-y-1.5">
+        <Label>Site Title</Label>
+        <Input
+         value={settings.siteTitle ?? ""}
+         onChange={(e) => set("siteTitle", e.target.value)}
+        />
+       </div>
+       <div className="space-y-1.5">
+        <Label>Meta Description</Label>
+        <Textarea
+         value={settings.siteDescription ?? ""}
+         onChange={(e) => set("siteDescription", e.target.value)}
+         rows={2}
+        />
+       </div>
+       <div className="space-y-1.5">
+        <Label>Footer Text</Label>
+        <Input
+         value={settings.footerText ?? ""}
+         onChange={(e) => set("footerText", e.target.value)}
+        />
+       </div>
+      </div>
+
+      {/* Accent Color */}
+      <div className="space-y-1.5">
+       <Label>Accent Color</Label>
+       <div className="flex items-start gap-3">
+        <div className="relative shrink-0">
+         <input
+          type="color"
+          id="accent-color-picker"
+          value={accentColor}
+          onChange={(e) => set("accentColor", e.target.value)}
+          className="sr-only"
+         />
+         <label
+          htmlFor="accent-color-picker"
+          className="block size-10 rounded-lg border-2 border-neutral-200 dark:border-neutral-700 shadow-sm cursor-pointer transition-transform hover:scale-105 active:scale-95"
+          style={{ backgroundColor: accentColor }}
+         />
+        </div>
+        <div className="flex-1 space-y-1.5">
+         <Input
+          value={accentColor}
+          onChange={(e) => set("accentColor", e.target.value)}
+          className="font-mono text-sm"
+          maxLength={7}
+          placeholder="#D4A853"
+         />
+         <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Used for highlights and interactive accents across the site.
+         </p>
+        </div>
+       </div>
+      </div>
+
+      {/* Maintenance Mode */}
+      <div className="flex items-center justify-between rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3">
+       <div>
+        <p className="text-sm font-medium">Maintenance Mode</p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+         Hides the site from all visitors
+        </p>
+       </div>
+       <Switch
+        checked={settings.maintenanceMode ?? false}
+        onCheckedChange={(v) => set("maintenanceMode", v)}
+       />
+      </div>
+
+      <Separator className="bg-neutral-200 dark:bg-neutral-800" />
+
+      {/* Public Pages */}
+      <div className="space-y-3">
+       <div>
+        <p className="text-sm font-semibold">Public Pages</p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+         Toggle which sections visitors can access. You always see all pages as admin.
+        </p>
+       </div>
+       {publicPages.map(({ key, label, description, icon: Icon }) => (
+        <div
+         key={key}
+         className="flex items-center justify-between rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3"
+        >
+         <div className="flex items-center gap-3">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
+           <Icon className="size-4 text-neutral-500 dark:text-neutral-400" />
+          </div>
+          <div>
+           <p className="text-sm font-medium">{label}</p>
+           <p className="text-xs text-neutral-500 dark:text-neutral-400">{description}</p>
+          </div>
+         </div>
+         <Switch checked={settings[key] ?? true} onCheckedChange={(v) => set(key, v)} />
+        </div>
+       ))}
+      </div>
+
+      <Separator className="bg-neutral-200 dark:bg-neutral-800" />
+
+      {/* Manage section */}
+      <div className="space-y-3">
+       <div>
+        <p className="text-sm font-semibold">Manage</p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+         Jump to other admin sections.
+        </p>
+       </div>
+       {managementItems.map(({ label, description, icon: Icon, drawer }) => (
+        <button
+         key={drawer}
+         type="button"
+         className="flex w-full items-center gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3 text-left cursor-pointer transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900"
+         onClick={() => openDrawer(drawer)}
+        >
+         <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
+          <Icon className="size-4 text-neutral-500 dark:text-neutral-400" />
+         </div>
+         <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium">{label}</p>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400 leading-snug">
+           {description}
+          </p>
+         </div>
+         <ChevronRight className="size-4 text-neutral-500 dark:text-neutral-400 shrink-0" />
+        </button>
+       ))}
+      </div>
+     </div>
+    </ScrollArea>
+
+    <div className="border-t border-neutral-200 dark:border-neutral-800 px-6 py-4 flex gap-3">
+     <Button onClick={handleSave} disabled={saving}>
+      {saving ? "Saving..." : "Save Settings"}
+     </Button>
+     <Button variant="outline" onClick={confirmClose}>
+      Cancel
+     </Button>
+    </div>
+   </SheetContent>
+   <UnsavedChangesDialog open={showConfirm} onConfirm={forceClose} onCancel={cancelClose} />
+  </Sheet>
+ );
+}

--- a/src/components/shared/settings-drawer.tsx
+++ b/src/components/shared/settings-drawer.tsx
@@ -79,29 +79,38 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
  const [loadError, setLoadError] = useState(false);
 
  useEffect(() => {
-  if (open && !loaded) {
-   setLoadError(false);
-   fetch("/api/settings")
-    .then((r) => {
-     if (!r.ok) throw new Error();
-     return r.json();
-    })
-    .then((s) => {
-     setSettings(s ?? {});
-     setLoaded(true);
-    })
-    .catch(() => {
-     setLoadError(true);
-     toast.error("Failed to load settings.");
-    });
-  }
   if (!open) {
    setLoaded(false);
    setLoadError(false);
+   return;
   }
+
+  if (loaded) return;
+
+  const controller = new AbortController();
+
+  setLoadError(false);
+  fetch("/api/settings", { signal: controller.signal })
+   .then((r) => {
+    if (!r.ok) throw new Error();
+    return r.json();
+   })
+   .then((s) => {
+    setSettings(s ?? {});
+    setLoaded(true);
+   })
+   .catch((err) => {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    setLoadError(true);
+    toast.error("Failed to load settings.");
+   });
+
+  return () => {
+   controller.abort();
+  };
  }, [open, loaded]);
 
- function set(key: string, value: unknown) {
+ function set<K extends keyof SiteSettingsData>(key: K, value: SiteSettingsData[K]) {
   markDirty();
   setSettings((prev) => ({ ...prev, [key]: value }));
  }
@@ -253,25 +262,29 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
          Jump to other admin sections.
         </p>
        </div>
-       {managementItems.map(({ label, description, icon: Icon, drawer }) => (
-        <button
-         key={drawer}
-         type="button"
-         className="flex w-full items-center gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3 text-left cursor-pointer transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900"
-         onClick={() => openDrawer(drawer)}
-        >
-         <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
-          <Icon className="size-4 text-neutral-500 dark:text-neutral-400" />
-         </div>
-         <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium">{label}</p>
-          <p className="text-xs text-neutral-500 dark:text-neutral-400 leading-snug">
-           {description}
-          </p>
-         </div>
-         <ChevronRight className="size-4 text-neutral-500 dark:text-neutral-400 shrink-0" />
-        </button>
-       ))}
+       {managementItems.map(({ label, description, icon: Icon, drawer }) => {
+        const isAvailable = drawer === "settings";
+        return (
+         <button
+          key={drawer}
+          type="button"
+          disabled={!isAvailable}
+          className="flex w-full items-center gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3 text-left cursor-pointer transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900 disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={() => openDrawer(drawer)}
+         >
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
+           <Icon className="size-4 text-neutral-500 dark:text-neutral-400" />
+          </div>
+          <div className="flex-1 min-w-0">
+           <p className="text-sm font-medium">{label}</p>
+           <p className="text-xs text-neutral-500 dark:text-neutral-400 leading-snug">
+            {description}
+           </p>
+          </div>
+          <ChevronRight className="size-4 text-neutral-500 dark:text-neutral-400 shrink-0" />
+         </button>
+        );
+       })}
       </div>
      </div>
     </ScrollArea>

--- a/src/components/shared/unsaved-changes-dialog.tsx
+++ b/src/components/shared/unsaved-changes-dialog.tsx
@@ -28,7 +28,7 @@ export function UnsavedChangesDialog({ open, onConfirm, onCancel }: UnsavedChang
      </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter>
-     <AlertDialogCancel onClick={onCancel}>Keep editing</AlertDialogCancel>
+     <AlertDialogCancel>Keep editing</AlertDialogCancel>
      <AlertDialogAction onClick={onConfirm}>Discard changes</AlertDialogAction>
     </AlertDialogFooter>
    </AlertDialogContent>

--- a/src/components/shared/unsaved-changes-dialog.tsx
+++ b/src/components/shared/unsaved-changes-dialog.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import {
+ AlertDialog,
+ AlertDialogAction,
+ AlertDialogCancel,
+ AlertDialogContent,
+ AlertDialogDescription,
+ AlertDialogFooter,
+ AlertDialogHeader,
+ AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface UnsavedChangesDialogProps {
+ open: boolean;
+ onConfirm: () => void;
+ onCancel: () => void;
+}
+
+export function UnsavedChangesDialog({ open, onConfirm, onCancel }: UnsavedChangesDialogProps) {
+ return (
+  <AlertDialog open={open} onOpenChange={(v) => !v && onCancel()}>
+   <AlertDialogContent>
+    <AlertDialogHeader>
+     <AlertDialogTitle>Unsaved changes</AlertDialogTitle>
+     <AlertDialogDescription>
+      You have unsaved changes. Are you sure you want to close without saving?
+     </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+     <AlertDialogCancel onClick={onCancel}>Keep editing</AlertDialogCancel>
+     <AlertDialogAction onClick={onConfirm}>Discard changes</AlertDialogAction>
+    </AlertDialogFooter>
+   </AlertDialogContent>
+  </AlertDialog>
+ );
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
    <AccordionPrimitive.Trigger
     data-slot="accordion-trigger"
     className={cn(
-     "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+     "focus-visible:border-neutral-400 dark:focus-visible:border-neutral-600 focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
      className
     )}
     {...props}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import * as React from "react";
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+ return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+ return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+ return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+ return (
+  <AlertDialogPrimitive.Overlay
+   data-slot="alert-dialog-overlay"
+   className={cn(
+    "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function AlertDialogContent({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+ return (
+  <AlertDialogPortal>
+   <AlertDialogOverlay />
+   <AlertDialogPrimitive.Content
+    data-slot="alert-dialog-content"
+    className={cn(
+     "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 p-6 shadow-lg duration-200 sm:max-w-lg data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+     className
+    )}
+    {...props}
+   />
+  </AlertDialogPortal>
+ );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div
+   data-slot="alert-dialog-header"
+   className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+   {...props}
+  />
+ );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div
+   data-slot="alert-dialog-footer"
+   className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+   {...props}
+  />
+ );
+}
+
+function AlertDialogTitle({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+ return (
+  <AlertDialogPrimitive.Title
+   data-slot="alert-dialog-title"
+   className={cn("text-lg font-semibold text-neutral-900 dark:text-neutral-100", className)}
+   {...props}
+  />
+ );
+}
+
+function AlertDialogDescription({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+ return (
+  <AlertDialogPrimitive.Description
+   data-slot="alert-dialog-description"
+   className={cn("text-sm text-neutral-500 dark:text-neutral-400", className)}
+   {...props}
+  />
+ );
+}
+
+function AlertDialogAction({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+ return (
+  <Button asChild>
+   <AlertDialogPrimitive.Action
+    data-slot="alert-dialog-action"
+    className={cn(className)}
+    {...props}
+   />
+  </Button>
+ );
+}
+
+function AlertDialogCancel({
+ className,
+ ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+ return (
+  <Button variant="outline" asChild>
+   <AlertDialogPrimitive.Cancel
+    data-slot="alert-dialog-cancel"
+    className={cn(className)}
+    {...props}
+   />
+  </Button>
+ );
+}
+
+export {
+ AlertDialog,
+ AlertDialogAction,
+ AlertDialogCancel,
+ AlertDialogContent,
+ AlertDialogDescription,
+ AlertDialogFooter,
+ AlertDialogHeader,
+ AlertDialogOverlay,
+ AlertDialogPortal,
+ AlertDialogTitle,
+ AlertDialogTrigger,
+};

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -17,7 +17,7 @@ function Avatar({
    data-slot="avatar"
    data-size={size}
    className={cn(
-    "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+    "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-neutral-200 dark:after:border-neutral-800 after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
     className
    )}
    {...props}
@@ -40,7 +40,7 @@ function AvatarFallback({ className, ...props }: AvatarPrimitive.Fallback.Props)
   <AvatarPrimitive.Fallback
    data-slot="avatar-fallback"
    className={cn(
-    "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
+    "flex size-full items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800 text-sm text-neutral-500 dark:text-neutral-400 group-data-[size=sm]/avatar:text-xs",
     className
    )}
    {...props}
@@ -53,7 +53,7 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
   <span
    data-slot="avatar-badge"
    className={cn(
-    "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background select-none",
+    "absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 bg-blend-color ring-2 ring-white dark:ring-neutral-950 select-none",
     "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
     "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
     "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
@@ -69,7 +69,7 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
   <div
    data-slot="avatar-group"
    className={cn(
-    "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+    "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-white dark:*:data-[slot=avatar]:ring-neutral-950",
     className
    )}
    {...props}
@@ -82,7 +82,7 @@ function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) 
   <div
    data-slot="avatar-group-count"
    className={cn(
-    "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+    "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-neutral-100 dark:bg-neutral-800 text-sm text-neutral-500 dark:text-neutral-400 ring-2 ring-white dark:ring-neutral-950 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
     className
    )}
    {...props}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,17 +7,21 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
- "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+ "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-neutral-400 dark:focus-visible:border-neutral-600 focus-visible:ring-[3px] focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-red-500 dark:aria-invalid:border-red-400 aria-invalid:ring-red-500/20 dark:aria-invalid:ring-red-400/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
  {
   variants: {
    variant: {
-    default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-    secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+    default:
+     "bg-neutral-900 dark:bg-neutral-100 text-white dark:text-neutral-900 [a]:hover:bg-neutral-900/80 dark:[a]:hover:bg-neutral-100/80",
+    secondary:
+     "bg-neutral-100 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 [a]:hover:bg-neutral-100/80 dark:[a]:hover:bg-neutral-800/80",
     destructive:
-     "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
-    outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-    ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-    link: "text-primary underline-offset-4 hover:underline",
+     "bg-red-500/10 text-red-500 dark:text-red-400 focus-visible:ring-red-500/20 dark:bg-red-500/20 dark:focus-visible:ring-red-400/40 [a]:hover:bg-red-500/20",
+    outline:
+     "border-neutral-200 dark:border-neutral-800 text-neutral-900 dark:text-neutral-100 [a]:hover:bg-neutral-100 dark:[a]:hover:bg-neutral-800 [a]:hover:text-neutral-500 dark:[a]:hover:text-neutral-400",
+    ghost:
+     "hover:bg-neutral-100 dark:hover:bg-neutral-800/50 hover:text-neutral-500 dark:hover:text-neutral-400",
+    link: "text-neutral-900 dark:text-neutral-100 underline-offset-4 hover:underline",
    },
   },
   defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,58 +1,66 @@
-"use client";
-
-import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-neutral-400 focus-visible:ring-3 focus-visible:ring-neutral-400/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-  {
-    variants: {
-      variant: {
-        default:
-          "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-50 dark:text-neutral-900 dark:hover:bg-neutral-200",
-        outline:
-          "border-neutral-200 bg-white hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-800 dark:bg-neutral-950 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
-        secondary:
-          "bg-neutral-100 text-neutral-900 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-50 dark:hover:bg-neutral-700",
-        ghost:
-          "hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-50",
-        destructive:
-          "bg-red-100 text-red-600 hover:bg-red-200 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30",
-        link: "text-neutral-900 underline-offset-4 hover:underline dark:text-neutral-50",
-      },
-      size: {
-        default: "h-8 gap-1.5 px-2.5",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-md px-2.5 text-[0.8rem] [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5",
-        icon: "size-8",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
-        "icon-sm": "size-7 rounded-md",
-        "icon-lg": "size-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
+ "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-neutral-400 focus-visible:ring-[3px] focus-visible:ring-neutral-400/50 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+ {
+  variants: {
+   variant: {
+    default:
+     "bg-neutral-900 text-white hover:bg-neutral-800 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-200",
+    destructive:
+     "bg-red-500 text-white hover:bg-red-600 focus-visible:ring-red-500/20 dark:bg-red-600 dark:hover:bg-red-700",
+    outline:
+     "border border-neutral-200 bg-white shadow-xs hover:bg-neutral-100 hover:text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100",
+    secondary:
+     "bg-neutral-100 text-neutral-900 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700",
+    ghost:
+     "hover:bg-neutral-100 hover:text-neutral-900 dark:hover:bg-neutral-800 dark:hover:text-neutral-100",
+    link: "text-neutral-900 dark:text-neutral-100 underline-offset-4 hover:underline",
+   },
+   size: {
+    default: "h-9 px-4 py-2 has-[>svg]:px-3",
+    xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+    sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
+    lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+    icon: "size-9",
+    "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+    "icon-sm": "size-8",
+    "icon-lg": "size-10",
+   },
+  },
+  defaultVariants: {
+   variant: "default",
+   size: "default",
+  },
+ }
 );
 
 function Button({
-  className,
-  variant = "default",
-  size = "default",
-  ...props
-}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
-  return (
-    <ButtonPrimitive
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  );
+ className,
+ variant = "default",
+ size = "default",
+ asChild = false,
+ ...props
+}: Omit<React.ComponentProps<"button">, "className"> &
+ VariantProps<typeof buttonVariants> & {
+  asChild?: boolean;
+  className?: string;
+ }) {
+ const Comp = asChild ? Slot.Root : "button";
+
+ return (
+  <Comp
+   data-slot="button"
+   data-variant={variant}
+   data-size={size}
+   className={cn(buttonVariants({ variant, size, className }))}
+   {...props}
+  />
+ );
 }
 
 export { Button, buttonVariants };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Input as InputPrimitive } from "@base-ui/react/input";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+ return (
+  <InputPrimitive
+   type={type}
+   data-slot="input"
+   className={cn(
+    "h-8 w-full min-w-0 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-neutral-900 dark:file:text-neutral-100 placeholder:text-neutral-500 dark:placeholder:text-neutral-400 focus-visible:border-neutral-400 dark:focus-visible:border-neutral-600 focus-visible:ring-3 focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-neutral-100/50 disabled:opacity-50 aria-invalid:border-red-500 aria-invalid:ring-3 aria-invalid:ring-red-500/20 md:text-sm dark:bg-neutral-800/30 dark:disabled:bg-neutral-800/80 dark:aria-invalid:border-red-500/50 dark:aria-invalid:ring-red-400/40",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+ return (
+  <label
+   data-slot="label"
+   className={cn(
+    "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+export { Label };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import * as React from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.Props) {
+ return (
+  <ScrollAreaPrimitive.Root
+   data-slot="scroll-area"
+   className={cn("relative", className)}
+   {...props}
+  >
+   <ScrollAreaPrimitive.Viewport
+    data-slot="scroll-area-viewport"
+    className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 focus-visible:outline-1"
+   >
+    {children}
+   </ScrollAreaPrimitive.Viewport>
+   <ScrollBar />
+   <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+ );
+}
+
+function ScrollBar({
+ className,
+ orientation = "vertical",
+ ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+ return (
+  <ScrollAreaPrimitive.Scrollbar
+   data-slot="scroll-area-scrollbar"
+   data-orientation={orientation}
+   orientation={orientation}
+   className={cn(
+    "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+    className
+   )}
+   {...props}
+  >
+   <ScrollAreaPrimitive.Thumb
+    data-slot="scroll-area-thumb"
+    className="relative flex-1 rounded-full bg-neutral-200 dark:bg-neutral-800"
+   />
+  </ScrollAreaPrimitive.Scrollbar>
+ );
+}
+
+export { ScrollArea, ScrollBar };

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -10,7 +10,7 @@ function Separator({ className, orientation = "horizontal", ...props }: Separato
    data-slot="separator"
    orientation={orientation}
    className={cn(
-    "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+    "shrink-0 bg-neutral-200 dark:bg-neutral-800 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
     className
    )}
    {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import * as React from "react";
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { XIcon } from "lucide-react";
+
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
+ return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
+ return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
+ return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
+ return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
+ return (
+  <SheetPrimitive.Backdrop
+   data-slot="sheet-overlay"
+   className={cn(
+    "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+function SheetContent({
+ className,
+ children,
+ side = "right",
+ showCloseButton = true,
+ ...props
+}: SheetPrimitive.Popup.Props & {
+ side?: "top" | "right" | "bottom" | "left";
+ showCloseButton?: boolean;
+}) {
+ return (
+  <SheetPortal>
+   <SheetOverlay />
+   <SheetPrimitive.Popup
+    data-slot="sheet-content"
+    data-side={side}
+    className={cn(
+     "fixed z-50 flex flex-col gap-4 bg-white dark:bg-neutral-950 bg-clip-padding text-sm text-neutral-900 dark:text-neutral-100 shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-[2.5rem] data-[side=bottom]:data-starting-style:translate-y-[2.5rem] data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:translate-x-[-2.5rem] data-[side=left]:data-starting-style:translate-x-[-2.5rem] data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:border-neutral-100 dark:data-[side=right]:border-neutral-900 data-[side=right]:data-ending-style:translate-x-[2.5rem] data-[side=right]:data-starting-style:translate-x-[2.5rem] data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:translate-y-[-2.5rem] data-[side=top]:data-starting-style:translate-y-[-2.5rem] data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+     className
+    )}
+    {...props}
+   >
+    {children}
+    {showCloseButton && (
+     <SheetPrimitive.Close
+      data-slot="sheet-close"
+      render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
+     >
+      <XIcon />
+      <span className="sr-only">Close</span>
+     </SheetPrimitive.Close>
+    )}
+   </SheetPrimitive.Popup>
+  </SheetPortal>
+ );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div data-slot="sheet-header" className={cn("flex flex-col gap-0.5 p-4", className)} {...props} />
+ );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+ return (
+  <div
+   data-slot="sheet-footer"
+   className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+   {...props}
+  />
+ );
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+ return (
+  <SheetPrimitive.Title
+   data-slot="sheet-title"
+   className={cn("text-base font-medium text-neutral-900 dark:text-neutral-100", className)}
+   {...props}
+  />
+ );
+}
+
+function SheetDescription({ className, ...props }: SheetPrimitive.Description.Props) {
+ return (
+  <SheetPrimitive.Description
+   data-slot="sheet-description"
+   className={cn("text-sm text-neutral-500 dark:text-neutral-400", className)}
+   {...props}
+  />
+ );
+}
+
+export {
+ Sheet,
+ SheetTrigger,
+ SheetClose,
+ SheetContent,
+ SheetHeader,
+ SheetFooter,
+ SheetTitle,
+ SheetDescription,
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+ className,
+ size = "default",
+ ...props
+}: SwitchPrimitive.Root.Props & {
+ size?: "sm" | "default";
+}) {
+ return (
+  <SwitchPrimitive.Root
+   data-slot="switch"
+   data-size={size}
+   className={cn(
+    "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-neutral-400 dark:focus-visible:border-neutral-600 focus-visible:ring-3 focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 aria-invalid:border-red-500 aria-invalid:ring-3 aria-invalid:ring-red-500/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-red-500/50 dark:aria-invalid:ring-red-400/40 data-checked:bg-neutral-900 dark:data-checked:bg-neutral-100 data-unchecked:bg-neutral-100 dark:data-unchecked:bg-neutral-800/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+    className
+   )}
+   {...props}
+  >
+   <SwitchPrimitive.Thumb
+    data-slot="switch-thumb"
+    className="pointer-events-none block rounded-full bg-white dark:bg-neutral-950 ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-neutral-900 group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-neutral-100"
+   />
+  </SwitchPrimitive.Root>
+ );
+}
+
+export { Switch };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+ return (
+  <textarea
+   data-slot="textarea"
+   className={cn(
+    "flex field-sizing-content min-h-16 w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-neutral-500 dark:placeholder:text-neutral-400 focus-visible:border-neutral-400 dark:focus-visible:border-neutral-600 focus-visible:ring-3 focus-visible:ring-neutral-400/50 dark:focus-visible:ring-neutral-600/50 disabled:cursor-not-allowed disabled:bg-neutral-100/50 disabled:opacity-50 aria-invalid:border-red-500 aria-invalid:ring-3 aria-invalid:ring-red-500/20 md:text-sm dark:bg-neutral-800/30 dark:disabled:bg-neutral-800/80 dark:aria-invalid:border-red-500/50 dark:aria-invalid:ring-red-400/40",
+    className
+   )}
+   {...props}
+  />
+ );
+}
+
+export { Textarea };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -38,13 +38,13 @@ function TooltipContent({
     <TooltipPrimitive.Popup
      data-slot="tooltip-content"
      className={cn(
-      "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+      "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-neutral-900 dark:bg-neutral-100 px-3 py-1.5 text-xs text-white dark:text-neutral-900 has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
       className
      )}
      {...props}
     >
      {children}
-     <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+     <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-neutral-900 dark:bg-neutral-100 fill-neutral-900 dark:fill-neutral-100 data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
     </TooltipPrimitive.Popup>
    </TooltipPrimitive.Positioner>
   </TooltipPrimitive.Portal>

--- a/src/hooks/use-confirm-close.ts
+++ b/src/hooks/use-confirm-close.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+
+export function useConfirmClose(onClose: () => void) {
+ const [showConfirm, setShowConfirm] = useState(false);
+ const dirtyRef = useRef(false);
+
+ const markDirty = useCallback(() => {
+  dirtyRef.current = true;
+ }, []);
+
+ const resetDirty = useCallback(() => {
+  dirtyRef.current = false;
+ }, []);
+
+ const confirmClose = useCallback(() => {
+  if (dirtyRef.current) {
+   setShowConfirm(true);
+  } else {
+   onClose();
+  }
+ }, [onClose]);
+
+ const cancelClose = useCallback(() => {
+  setShowConfirm(false);
+ }, []);
+
+ const forceClose = useCallback(() => {
+  dirtyRef.current = false;
+  setShowConfirm(false);
+  onClose();
+ }, [onClose]);
+
+ return { markDirty, resetDirty, confirmClose, showConfirm, cancelClose, forceClose };
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build a settings drawer accessible from the admin dock that allows managing site-wide configuration including metadata, appearance, and page visibility.

**Changes:**
- Add site settings drawer with metadata, accent color, and page visibility
- Address review feedback on settings drawer

**Impact:**
- `package-lock.json` — Modified (+10, -0)
- `package.json` — Modified (+1, -0)
- `src/app/(public)/layout.tsx` — Modified (+6, -0)
- `src/components/shared/global-drawers.tsx` — Added (+15, -0)
- `src/components/shared/settings-drawer.tsx` — Added (+304, -0)
- `src/components/shared/unsaved-changes-dialog.tsx` — Added (+37, -0)
- `src/components/ui/accordion.tsx` — Modified (+1, -1)
- `src/components/ui/alert-dialog.tsx` — Added (+146, -0)
- `src/components/ui/avatar.tsx` — Modified (+5, -5)
- `src/components/ui/badge.tsx` — Modified (+11, -7)
- `src/components/ui/button.tsx` — Modified (+55, -47)
- `src/components/ui/input.tsx` — Added (+20, -0)
- `src/components/ui/label.tsx` — Added (+20, -0)
- `src/components/ui/scroll-area.tsx` — Added (+51, -0)
- `src/components/ui/separator.tsx` — Modified (+1, -1)
- `src/components/ui/sheet.tsx` — Added (+121, -0)
- `src/components/ui/switch.tsx` — Added (+32, -0)
- `src/components/ui/textarea.tsx` — Added (+18, -0)
- `src/components/ui/tooltip.tsx` — Modified (+2, -2)
- `src/hooks/use-confirm-close.ts` — Added (+36, -0)

## Linked Issue
**#24** — Build site settings drawer

Closes #24