### PR TITLE
feat(ui): add user management drawer with add, list, and delete

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -4,7 +4,7 @@ import { requireAuth, jsonError, isNotFoundError } from "@/lib/api-utils";
 import { createUserSchema } from "@/lib/validations";
 
 export async function GET() {
- const { error } = await requireAuth();
+ const { error, session } = await requireAuth();
  if (error) return error;
 
  try {
@@ -12,7 +12,13 @@ export async function GET() {
    select: { id: true, name: true, email: true, createdAt: true },
    orderBy: { createdAt: "asc" },
   });
-  return NextResponse.json(users);
+
+  const currentUser = await prisma.user.findUnique({
+   where: { email: session.user.email! },
+   select: { id: true },
+  });
+
+  return NextResponse.json({ users, currentUserId: currentUser?.id ?? null });
  } catch {
   return jsonError("Failed to fetch users", 500);
  }

--- a/src/components/shared/confirm-delete-dialog.tsx
+++ b/src/components/shared/confirm-delete-dialog.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+ AlertDialog,
+ AlertDialogAction,
+ AlertDialogCancel,
+ AlertDialogContent,
+ AlertDialogDescription,
+ AlertDialogFooter,
+ AlertDialogHeader,
+ AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ConfirmDeleteDialogProps {
+ open: boolean;
+ title?: string;
+ description?: string;
+ onConfirm: () => void;
+ onCancel: () => void;
+}
+
+export function ConfirmDeleteDialog({
+ open,
+ title = "Are you sure?",
+ description = "This action cannot be undone.",
+ onConfirm,
+ onCancel,
+}: ConfirmDeleteDialogProps) {
+ return (
+  <AlertDialog open={open} onOpenChange={(v) => !v && onCancel()}>
+   <AlertDialogContent>
+    <AlertDialogHeader>
+     <AlertDialogTitle>{title}</AlertDialogTitle>
+     <AlertDialogDescription>{description}</AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+     <AlertDialogCancel>Cancel</AlertDialogCancel>
+     <AlertDialogAction onClick={onConfirm}>Delete</AlertDialogAction>
+    </AlertDialogFooter>
+   </AlertDialogContent>
+  </AlertDialog>
+ );
+}

--- a/src/components/shared/global-drawers.tsx
+++ b/src/components/shared/global-drawers.tsx
@@ -3,6 +3,7 @@
 import { useDrawerState } from "./drawer-state-provider";
 import { SettingsDrawer } from "./settings-drawer";
 import { ProfileDrawer } from "./profile-drawer";
+import { UsersDrawer } from "./users-drawer";
 
 export function GlobalDrawers() {
  const { open, closeDrawer } = useDrawerState();
@@ -11,7 +12,8 @@ export function GlobalDrawers() {
   <>
    <SettingsDrawer open={open === "settings"} onClose={closeDrawer} />
    <ProfileDrawer open={open === "profile"} onClose={closeDrawer} />
-   {/* Future drawers: cv-experience, cv-education, cv-skill, cv-documents, users */}
+   <UsersDrawer open={open === "users"} onClose={closeDrawer} />
+   {/* Future drawers: cv-experience, cv-education, cv-skill, cv-documents */}
   </>
  );
 }

--- a/src/components/shared/settings-drawer.tsx
+++ b/src/components/shared/settings-drawer.tsx
@@ -270,7 +270,10 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           type="button"
           disabled={!isAvailable}
           className="flex w-full items-center gap-3 rounded-lg border border-neutral-200 dark:border-neutral-800 px-4 py-3 text-left cursor-pointer transition-colors hover:bg-neutral-50 dark:hover:bg-neutral-900 disabled:opacity-50 disabled:cursor-not-allowed"
-          onClick={() => openDrawer(drawer)}
+          onClick={() => {
+           resetDirty();
+           openDrawer(drawer);
+          }}
          >
           <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-neutral-100 dark:bg-neutral-800">
            <Icon className="size-4 text-neutral-500 dark:text-neutral-400" />

--- a/src/components/shared/settings-drawer.tsx
+++ b/src/components/shared/settings-drawer.tsx
@@ -263,7 +263,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         </p>
        </div>
        {managementItems.map(({ label, description, icon: Icon, drawer }) => {
-        const isAvailable = drawer === "settings";
+        const isAvailable = drawer === "settings" || drawer === "users";
         return (
          <button
           key={drawer}

--- a/src/components/shared/users-drawer.tsx
+++ b/src/components/shared/users-drawer.tsx
@@ -70,16 +70,14 @@ export function UsersDrawer({ open, onClose }: UsersDrawerProps) {
   e.preventDefault();
   setAdding(true);
   try {
-   const res = (await apiFetch("/api/users", {
+   const user = await apiFetch<UserItem>("/api/users", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
      email,
      name,
      ...(password ? { password } : {}),
     }),
-   })) as Response;
-   const user = await res.json();
+   });
    setUsers((prev) => [user, ...prev]);
    setEmail("");
    setName("");
@@ -186,6 +184,7 @@ export function UsersDrawer({ open, onClose }: UsersDrawerProps) {
            <Button
             variant="ghost"
             size="icon"
+            aria-label={`Remove ${user.name}`}
             className="shrink-0 text-neutral-400 hover:text-red-500"
             onClick={() => setDeleteUserId(user.id)}
            >

--- a/src/components/shared/users-drawer.tsx
+++ b/src/components/shared/users-drawer.tsx
@@ -70,7 +70,7 @@ export function UsersDrawer({ open, onClose }: UsersDrawerProps) {
   e.preventDefault();
   setAdding(true);
   try {
-   const res = await apiFetch("/api/users", {
+   const res = (await apiFetch("/api/users", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -78,7 +78,7 @@ export function UsersDrawer({ open, onClose }: UsersDrawerProps) {
      name,
      ...(password ? { password } : {}),
     }),
-   });
+   })) as Response;
    const user = await res.json();
    setUsers((prev) => [user, ...prev]);
    setEmail("");

--- a/src/components/shared/users-drawer.tsx
+++ b/src/components/shared/users-drawer.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { apiFetch } from "@/lib/api-client";
+import { ConfirmDeleteDialog } from "./confirm-delete-dialog";
+import { UnsavedChangesDialog } from "./unsaved-changes-dialog";
+import { useConfirmClose } from "@/hooks/use-confirm-close";
+
+interface UserItem {
+ id: string;
+ email: string;
+ name: string;
+}
+
+interface UsersDrawerProps {
+ open: boolean;
+ onClose: () => void;
+}
+
+export function UsersDrawer({ open, onClose }: UsersDrawerProps) {
+ const { markDirty, resetDirty, confirmClose, showConfirm, cancelClose, forceClose } =
+  useConfirmClose(onClose);
+ const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+ const [users, setUsers] = useState<UserItem[]>([]);
+ const [loading, setLoading] = useState(false);
+ const [adding, setAdding] = useState(false);
+ const [email, setEmail] = useState("");
+ const [name, setName] = useState("");
+ const [password, setPassword] = useState("");
+ const [deleteUserId, setDeleteUserId] = useState<string | null>(null);
+
+ useEffect(() => {
+  if (!open) {
+   setUsers([]);
+   setCurrentUserId(null);
+   return;
+  }
+
+  const controller = new AbortController();
+  setLoading(true);
+
+  fetch("/api/users", { signal: controller.signal })
+   .then((r) => {
+    if (!r.ok) throw new Error();
+    return r.json();
+   })
+   .then((data) => {
+    setUsers(data.users);
+    setCurrentUserId(data.currentUserId);
+   })
+   .catch((err) => {
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    toast.error("Failed to load users.");
+   })
+   .finally(() => setLoading(false));
+
+  return () => {
+   controller.abort();
+  };
+ }, [open]);
+
+ async function handleAdd(e: React.FormEvent) {
+  e.preventDefault();
+  setAdding(true);
+  try {
+   const res = await apiFetch("/api/users", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+     email,
+     name,
+     ...(password ? { password } : {}),
+    }),
+   });
+   const user = await res.json();
+   setUsers((prev) => [user, ...prev]);
+   setEmail("");
+   setName("");
+   setPassword("");
+   resetDirty();
+   toast.success("User added!");
+  } catch (err) {
+   toast.error(err instanceof Error ? err.message : "Failed to add user.");
+  } finally {
+   setAdding(false);
+  }
+ }
+
+ async function handleDelete() {
+  if (!deleteUserId) return;
+  try {
+   await apiFetch(`/api/users?id=${deleteUserId}`, { method: "DELETE" });
+   setUsers((prev) => prev.filter((u) => u.id !== deleteUserId));
+   toast.success("User removed.");
+  } catch (err) {
+   toast.error(err instanceof Error ? err.message : "Delete failed.");
+  } finally {
+   setDeleteUserId(null);
+  }
+ }
+
+ return (
+  <Sheet open={open} onOpenChange={(v) => !v && confirmClose()}>
+   <SheetContent className="w-full sm:max-w-lg! p-0 flex flex-col">
+    <SheetHeader className="px-6 pt-6 pb-4">
+     <SheetTitle>Manage Users</SheetTitle>
+    </SheetHeader>
+
+    <ScrollArea className="flex-1 min-h-0 px-6">
+     <div className="space-y-6 pb-6">
+      {/* Add user form */}
+      <form
+       onSubmit={handleAdd}
+       className="space-y-3 rounded-lg border border-neutral-200 dark:border-neutral-800 p-4"
+      >
+       <p className="text-sm font-medium">Add a new user</p>
+       <div className="space-y-1.5">
+        <Label htmlFor="new-name">Name</Label>
+        <Input
+         id="new-name"
+         value={name}
+         onChange={(e) => {
+          markDirty();
+          setName(e.target.value);
+         }}
+         placeholder="Jane Doe"
+         required
+        />
+       </div>
+       <div className="space-y-1.5">
+        <Label htmlFor="new-email">Email</Label>
+        <Input
+         id="new-email"
+         type="email"
+         value={email}
+         onChange={(e) => {
+          markDirty();
+          setEmail(e.target.value);
+         }}
+         placeholder="jane@example.com"
+         required
+        />
+       </div>
+       <div className="space-y-1.5">
+        <Label htmlFor="new-password">Password (optional)</Label>
+        <Input
+         id="new-password"
+         type="password"
+         value={password}
+         onChange={(e) => {
+          markDirty();
+          setPassword(e.target.value);
+         }}
+         placeholder="Leave blank for SSO-only"
+         minLength={6}
+        />
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+         If empty, the user can only sign in via Google or GitHub.
+        </p>
+       </div>
+       <Button type="submit" size="sm" disabled={adding}>
+        {adding ? "Adding..." : "Add User"}
+       </Button>
+      </form>
+
+      {/* Users list */}
+      <div className="space-y-1">
+       <p className="text-sm font-medium text-neutral-500 dark:text-neutral-400">
+        {loading ? "Loading..." : `${users.length} user${users.length !== 1 ? "s" : ""}`}
+       </p>
+       <div className="divide-y divide-neutral-200 dark:divide-neutral-800">
+        {users.map((user) => (
+         <div key={user.id} className="flex items-center justify-between py-3 gap-3">
+          <div className="min-w-0">
+           <p className="text-sm font-medium truncate">{user.name}</p>
+           <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">{user.email}</p>
+          </div>
+          {user.id !== currentUserId && (
+           <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 text-neutral-400 hover:text-red-500"
+            onClick={() => setDeleteUserId(user.id)}
+           >
+            <Trash2 className="size-4" />
+           </Button>
+          )}
+         </div>
+        ))}
+       </div>
+      </div>
+     </div>
+    </ScrollArea>
+   </SheetContent>
+   <UnsavedChangesDialog open={showConfirm} onConfirm={forceClose} onCancel={cancelClose} />
+   <ConfirmDeleteDialog
+    open={!!deleteUserId}
+    title="Remove user?"
+    description="This user will no longer be able to sign in."
+    onConfirm={handleDelete}
+    onCancel={() => setDeleteUserId(null)}
+   />
+  </Sheet>
+ );
+}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Build a user management drawer accessible from the site settings that allows adding and removing admin users who can access the inline editing features.

**Changes:**
- Add user management drawer with add, list, and delete
- Type apiFetch response in users drawer
- Fix API shape, apiFetch usage, and accessibility in users drawer

**Impact:**
- `src/app/api/users/route.ts` — Modified (+8, -2)
- `src/components/shared/confirm-delete-dialog.tsx` — Added (+43, -0)
- `src/components/shared/global-drawers.tsx` — Modified (+3, -1)
- `src/components/shared/settings-drawer.tsx` — Modified (+5, -2)
- `src/components/shared/users-drawer.tsx` — Added (+211, -0)

## Linked Issue
**#26** — Build user management drawer

Closes #26