### PR TITLE
hotfix(ci): exempt Dependabot branches from naming enforcement

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -21,9 +21,14 @@ jobs:
         run: |
           BRANCH="${{ github.head_ref }}"
 
-          # Skip validation for base branches
+          # Skip validation for base branches and automated bot branches
           if [[ "$BRANCH" == "develop" || "$BRANCH" == "master" ]]; then
             echo "✅ Base branch '$BRANCH' — skipping validation."
+            exit 0
+          fi
+
+          if [[ "$BRANCH" == dependabot/* ]]; then
+            echo "✅ Dependabot branch '$BRANCH' — skipping validation."
             exit 0
           fi
 


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Dependabot creates branches like `dependabot/npm_and_yarn/...` which fail the branch naming enforcement workflow. Exempt Dependabot branches from validation so automated dependency PRs can pass CI checks.

**Changes:**
- Exempt Dependabot branches from naming enforcement

**Impact:**
- `.github/workflows/branch-naming.yml` — Modified (+6, -1)

## Linked Issue
**#90** — Exempt Dependabot branches from branch naming enforcement

Closes #90