### PR TITLE
hotfix(ci): skip E2E for Dependabot and add env fallbacks for CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      # Provide fallback for Dependabot PRs that can't access secrets
+      # Fallback values for Dependabot PRs (can't access secrets).
+      # These allow the build to compile but never connect to a real database.
       DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://placeholder:placeholder@localhost:5432/placeholder' }}
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-placeholder-secret' }}
       NEXTAUTH_URL: http://localhost:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
     name: Test, Type Check, Lint & Build
     runs-on: ubuntu-latest
 
+    env:
+      # Provide fallback for Dependabot PRs that can't access secrets
+      DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://placeholder:placeholder@localhost:5432/placeholder' }}
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-placeholder-secret' }}
+      NEXTAUTH_URL: http://localhost:3000
+
     steps:
       # 1. Check out the code
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,8 @@ jobs:
   runs-on: ubuntu-latest
   timeout-minutes: 15
 
-  # Skip forked PRs — secrets are not available
-  if: github.event.pull_request.head.repo.full_name == github.repository
+  # Skip forked PRs and Dependabot — secrets may not be available
+  if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
 
   env:
    DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
   timeout-minutes: 15
 
   # Skip forked PRs and Dependabot — secrets may not be available
-  if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+  if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]'
 
   env:
    DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
<!-- auto-generated-pr-description -->
## Scope
Dependabot PRs fail CI and E2E checks because they can't access repository secrets. Skip E2E for Dependabot and provide environment variable fallbacks in CI so builds can compile.

**Changes:**
- Skip E2E for Dependabot and add env fallbacks for CI build
- Use PR author for Dependabot check and clarify env fallbacks

**Impact:**
- `.github/workflows/ci.yml` — Modified (+7, -0)
- `.github/workflows/e2e.yml` — Modified (+2, -2)

## Linked Issue
**#110** — Fix CI and E2E workflows for Dependabot PRs

Closes #110