### PR TITLE
feat(auth): replace password login with GitHub + Google OAuth

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { signIn } from "next-auth/react";
-import { Suspense, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 export default function LoginPage() {
@@ -14,77 +14,37 @@ export default function LoginPage() {
 }
 
 function LoginForm() {
- const router = useRouter();
  const searchParams = useSearchParams();
  const callbackUrl = searchParams.get("callbackUrl") || "/";
- const [email, setEmail] = useState("");
- const [password, setPassword] = useState("");
- const [error, setError] = useState("");
- const [loading, setLoading] = useState(false);
-
- async function handleSubmit(e: React.FormEvent) {
-  e.preventDefault();
-  setError("");
-  setLoading(true);
-
-  const result = await signIn("credentials", {
-   email,
-   password,
-   redirect: false,
-   callbackUrl,
-  });
-
-  setLoading(false);
-
-  if (result?.error) {
-   setError("Invalid email or password");
-  } else {
-   const targetUrl = result?.url || "/";
-   router.push(targetUrl);
-   router.refresh();
-  }
- }
+ const error = searchParams.get("error");
 
  return (
   <div className="flex min-h-screen items-center justify-center">
    <div className="w-full max-w-sm space-y-6 p-6">
     <h1 className="text-center text-2xl font-bold">Sign In</h1>
 
-    <form onSubmit={handleSubmit} className="space-y-4">
-     <div>
-      <label htmlFor="email" className="block text-sm font-medium">
-       Email
-      </label>
-      <input
-       id="email"
-       type="email"
-       value={email}
-       onChange={(e) => setEmail(e.target.value)}
-       required
-       className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
-      />
-     </div>
-
-     <div>
-      <label htmlFor="password" className="block text-sm font-medium">
-       Password
-      </label>
-      <input
-       id="password"
-       type="password"
-       value={password}
-       onChange={(e) => setPassword(e.target.value)}
-       required
-       className="mt-1 w-full rounded-md border border-neutral-300 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-900"
-      />
-     </div>
-
-     {error && <p className="text-sm text-red-500">{error}</p>}
-
-     <Button type="submit" className="w-full" disabled={loading}>
-      {loading ? "Signing in..." : "Sign In"}
+    <div className="space-y-3">
+     <Button type="button" className="w-full" onClick={() => signIn("github", { callbackUrl })}>
+      Continue with GitHub
      </Button>
-    </form>
+
+     <Button
+      type="button"
+      variant="outline"
+      className="w-full"
+      onClick={() => signIn("google", { callbackUrl })}
+     >
+      Continue with Google
+     </Button>
+    </div>
+
+    {error && (
+     <p className="text-center text-sm text-red-500">
+      {error === "AccessDenied"
+       ? "This account isn't authorized to sign in."
+       : "Sign-in failed. Please try again."}
+     </p>
+    )}
    </div>
   </div>
  );


### PR DESCRIPTION
## Summary
- Replaces the email/password form on `/login` with two OAuth buttons: **Continue with GitHub** and **Continue with Google**
- Surfaces OAuth errors (e.g. `AccessDenied`) via `?error=` query param on the login page
- No changes to [src/lib/auth.ts](src/lib/auth.ts) — GitHub and Google providers were already conditionally registered based on env vars

Closes #112

## Required setup (local dev)
Add to `.env`:
- `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` — OAuth app at https://github.com/settings/developers
- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — OAuth client at https://console.cloud.google.com/apis/credentials

Callback URLs to register on the OAuth apps:
- `http://localhost:3000/api/auth/callback/github`
- `http://localhost:3000/api/auth/callback/google`

Production callbacks (`https://nathalie.work/...`) to be added when deploying.

## Test plan
- [ ] `npm run dev` → visit http://localhost:3000/login → see both OAuth buttons, no password form
- [ ] Click **Continue with GitHub** → authorize → land back on site logged in as `mninanathalie@gmail.com`
- [ ] Click **Continue with Google** → authorize → land back on site logged in
- [ ] Attempt sign-in with a non-seeded email → should be rejected (sign-in callback in [src/lib/auth.ts](src/lib/auth.ts#L55-L95) rejects unknown emails) and redirect to `/login?error=AccessDenied` showing the inline error message
- [ ] `npm run test:e2e` — confirm Playwright login spec still passes (or update if needed)

## Out of scope (follow-up issues)
- Remove unused `CredentialsProvider` from [src/lib/auth.ts](src/lib/auth.ts)
- Drop `passwordHash` column from the `User` Prisma model
- Passkey / WebAuthn (requires next-auth v4 → Auth.js v5 upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)